### PR TITLE
feat: publish a GitHub release from release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,17 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # Inert until a release branch exists: a push runs the workflow file as
+    # it stands on the pushed branch.
+    branches: [main, 'release/**']
   # No base-branch filter: stacked PRs target intermediate heads, not only main.
   pull_request:
   workflow_dispatch:
 
 concurrency:
-  # Separate groups per event type so a push to main doesn't cancel an
-  # in-flight manual release. workflow_dispatch keys on run_id (unique
-  # per click) and disables cancel-in-progress; dispatches are further
-  # serialized at the publish step via the per-job concurrency on
-  # github-release.
+  # Only pull requests supersede each other. Everything else keys on run_id,
+  # so a second push to a release branch cannot cancel an in-flight publish.
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
@@ -102,13 +101,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
+          fetch-depth: 0 # ci/version.sh needs the history behind the branch point
 
       - name: Compute release metadata
         id: version
         run: |
-          VERSION="$(date -u +'%Y.%m.%d')-$(git rev-parse --short HEAD)"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Assign first: `echo "v=$(cmd)"` succeeds even when cmd fails, and
+          # the default shell is `bash -e` with no pipefail, so piping the echo
+          # straight into tee would swallow the failure and emit an empty
+          # version.
+          set -euo pipefail
+          version="$(ci/version.sh)"
+          echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
 
   conventions:
     # Lightweight repo-convention checks (see ci/README.md). Its own job so a
@@ -1097,38 +1101,55 @@ jobs:
           esac
 
   github-release:
-    # Manual-only: trigger from Actions UI ("Run workflow") on the ref you
-    # want to release. The whole build pipeline runs against that ref and
-    # publishes the artifacts. Push to main still runs CI (build-complete)
-    # but does not publish.
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
     needs: [release-metadata, build-complete]
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    # Serialize concurrent manual dispatches against the same ref so two
-    # clicks don't race each other creating the same release tag.
+    # Serialize publishes against one release branch so two pushes can't race
+    # to create the same tag.
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       contents: write
     steps:
+      # The version carries the commit, so this only fires when the same
+      # commit is published twice — a re-run. It never blocks a real push.
+      - name: Skip if this release already exists
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VER: ${{ needs.release-metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "${VER}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::notice::release ${VER} already exists — not republishing"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publishing ${VER}"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Pinned: this is the only job with a repo-write token, so a moved tag here
       # could publish a release. Read-only jobs above still ride tags.
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        if: steps.guard.outputs.skip != 'true'
         with:
           pattern: "pipette-*"
           merge-multiple: true
           path: dist
 
       - name: Stage Android release APK (versioned)
+        if: steps.guard.outputs.skip != 'true'
         # The android-app job uploads the production APK as `pipette-release-apk`
         # (file: app-release.apk), which the download above flattens into dist/.
         # Rename it to a versioned asset so the release carries `pipette-<ver>.apk`
-        # rather than a generic name. Target app-release.apk explicitly so the
-        # co-downloaded debug APK (app-debug.apk) is never published.
+        # rather than a generic name. The debug APK rides along in the same
+        # download; drop it so it is neither published nor checksummed.
         run: |
+          set -euo pipefail
           ver='${{ needs.release-metadata.outputs.version }}'
-          if [ -f dist/app-release.apk ]; then
+          rm -f dist/app-debug.apk
+          if [[ -f dist/app-release.apk ]]; then
             mv dist/app-release.apk "dist/pipette-${ver}.apk"
             echo "staged dist/pipette-${ver}.apk"
           else
@@ -1136,12 +1157,30 @@ jobs:
             ls -la dist || true
           fi
 
+      - name: Checksum release assets
+        if: steps.guard.outputs.skip != 'true'
+        # One `<asset>.sha256` beside each file, matching pipette-mgmt's layout.
+        # This proves a download arrived intact; it is not a signature, since
+        # anyone able to replace an asset can replace its checksum too.
+        run: |
+          set -euo pipefail
+          cd dist
+          for f in *; do
+            [[ -f "$f" ]] || continue
+            sha256sum "$f" > "${f}.sha256"
+          done
+          ls -1
+
       - name: Create GitHub release
+        if: steps.guard.outputs.skip != 'true'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.release-metadata.outputs.version }}
           name: ${{ needs.release-metadata.outputs.version }}
           generate_release_notes: true
+          # Archives are listed explicitly so nothing unexpected in dist/ can
+          # ship. The `*.sha256` glob is safe because the staging step removed
+          # the only file that must not be published.
           files: |
             dist/pipette-${{ needs.release-metadata.outputs.version }}.apk
             dist/pipette-ios-${{ needs.release-metadata.outputs.version }}-internal.xcarchive.zip
@@ -1156,3 +1195,4 @@ jobs:
             dist/pipette-cli-x86_64-pc-windows-msvc.zip
             dist/pipette-cli-aarch64-pc-windows-msvc.zip
             dist/pipette-cli-aarch64-linux-android.tar.gz
+            dist/*.sha256

--- a/ci/version.sh
+++ b/ci/version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# The version a build publishes as. Also runnable locally: `ci/version.sh`
+# answers "what would this commit publish as?" without pushing.
+#
+#   release/2026.08.1 three commits in -> 2026.08.1-3-ga1b2c3d4ab
+#   anything else                      -> the bare commit sha
+#
+# The release form is the train from the branch name, the distance from the
+# branch point, and the commit. Nothing reads the clock and nothing needs a
+# pre-existing tag, so a commit always names itself the same way. It is also
+# the shape `git describe` emits, so tagging branch points later changes
+# nothing.
+#
+# The one thing that can renumber a released commit is rewriting main: the
+# distance is measured from `git merge-base origin/main HEAD`, so a force-push
+# that moves the branch point moves the count with it.
+set -euo pipefail
+
+ref="${GITHUB_REF:-refs/heads/$(git rev-parse --abbrev-ref HEAD)}"
+
+case "$ref" in
+  refs/heads/release/*)
+    train="${ref#refs/heads/release/}"
+    # `release/**` matches nested names. A `/` would nest inside the release
+    # tag here, and is outright illegal as an image tag in the sibling repos,
+    # so keep trains flat everywhere and fail on the branch name.
+    case "$train" in
+      */*) echo "release branch must not nest: ${train}" >&2; exit 1 ;;
+    esac
+    # Distance from where the branch left main. Merging main back in adds only
+    # the merge commit, so this never goes backwards.
+    base="$(git merge-base origin/main HEAD)"
+    echo "${train}-$(git rev-list --count "${base}..HEAD")-g$(git rev-parse --short=10 HEAD)"
+    ;;
+  *) git rev-parse --short=10 HEAD ;;
+esac


### PR DESCRIPTION
**Problem**
The `release/<train>` branch convention already exists, but nothing is wired to it. Pushes to `release/**` ran no workflow at all, and `github-release` required a `workflow_dispatch` on `main`, so cutting a release branch published nothing. The 13 release assets also shipped with no checksums.

**Solution**
- Runs the full pipeline and publishes on push to `release/**`; main and pull requests run CI only
- Versions from the branch and the commit graph: `2026.08.1-3-ga1b2c3d4ab` — train, distance from the branch point, commit. No clock and no pre-existing tag, so a commit always names itself the same way
- Publishes a `<asset>.sha256` beside every attached archive, matching `pipette-mgmt`'s layout
- Drops the debug APK from `dist/` so it is neither published nor checksummed
- Skips publishing when the version already has a release, so a re-run cannot move a tag
- Retains release artifacts for a year, pull-request artifacts for 14 days
- Adds `ci/version.sh`, runnable locally to answer what a commit would publish as

**Cutting a train**
```
git switch -c release/2026.08.1 main
git push -u origin release/2026.08.1
```
No tag to create first — the version comes from the branch name and the commit graph.

**Testing**
- CI green on this branch; `github-release` correctly skips on pull requests
- `ci/version.sh` exercised across main, a fresh release branch, one three commits in, after main moves, after merging main back, and a second concurrent train
- Staging + checksum sequence simulated over a representative `dist/`: no debug APK, no orphan checksums, `sha256sum -c` verifies
- `./ci/lint.sh` passes