### PR TITLE
ci: move all jobs from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/workflows/android-release-distribution.yml
+++ b/.github/workflows/android-release-distribution.yml
@@ -169,7 +169,7 @@ jobs:
        github.repository == 'Liquid4All/pipette-clients') ||
       (github.event.label.name == 'build-deploy-firebase' &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Gate the job behind a protected environment with required reviewers. Every
     # run (whether started by the `build-deploy-firebase` label or a manual
     # dispatch, and whichever `distribution` mode) pauses for maintainer approval

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     # Detect what changed so PRs that don't touch Rust/iOS code can skip
     # the expensive compile jobs. Push events (main) always run everything
     # so releases keep building regardless of which paths changed.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # paths-filter reads a pull_request's files via `pulls.listFiles`, which needs
     # `pull-requests: read`. Granted only here; `contents: read` is restated
     # because a job block replaces the top-level default.
@@ -96,7 +96,7 @@ jobs:
               - '.github/**'
 
   release-metadata:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -114,7 +114,7 @@ jobs:
     # Lightweight repo-convention checks (see ci/README.md). Its own job so a
     # failure shows up as a distinct `conventions` status, not buried in
     # rust-check; needs no Rust toolchain, so it stays fast and parallel.
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Convention checks
@@ -130,17 +130,17 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             fmt: true
             # Both cargo-deny gates read the dependency graph for every target in
             # deny.toml, so their result is identical on all three runners.
             deny: true
           - os: macos
-            runner: blacksmith-6vcpu-macos-26
+            runner: macos-26
           - os: windows
             # rust-check on Windows recompiles the whole workspace every run
             # (cache-bin: false), so it's the CPU-bound leg of the matrix.
-            runner: blacksmith-2vcpu-windows-2025
+            runner: windows-2025
     steps:
       - uses: actions/checkout@v6
         with:
@@ -239,7 +239,7 @@ jobs:
     name: python-check
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.python == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -269,7 +269,7 @@ jobs:
     # The iOS app links no Rust (native-Swift llama.cpp via build-llama.sh), so
     # it keys only on iOS changes. `changes.ios` already covers ios/** + .github/**.
     if: github.event_name != 'pull_request' || needs.changes.outputs.ios == 'true'
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: macos-26
     env:
       # Pin the toolchain instead of taking the image default (26.2): the
       # project's deployment target is 26.4 (beyond 26.2's supported range),
@@ -449,7 +449,7 @@ jobs:
     # github-release publishes from.
     needs: [release-metadata, changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.ios == 'true'
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: macos-26
     env:
       # Same toolchain pin as ios-check — see the note there.
       DEVELOPER_DIR: /Applications/Xcode_26.4.app
@@ -619,7 +619,7 @@ jobs:
     name: android-app
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -784,7 +784,7 @@ jobs:
     name: android-lint
     needs: [changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -844,7 +844,7 @@ jobs:
           # Android: the unified pipette client, pushed to devices via adb.
           # pipette-plan is not shipped for Android, so no plan_asset_name here.
           - target: aarch64-linux-android
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             asset_name: pipette-cli-aarch64-linux-android.tar.gz
             archive: tar.gz
             android: true
@@ -860,14 +860,14 @@ jobs:
           # binary, and carries pipette-plan as its own `plan_asset_name` artifact
           # on each desktop target (the runner ships alongside the client).
           - target: x86_64-unknown-linux-gnu
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             asset_name: pipette-cli-x86_64-unknown-linux-gnu.tar.gz
             archive: tar.gz
             packages: pipette-cli pipette-plan
             binaries: pipette
             plan_asset_name: pipette-plan-x86_64-unknown-linux-gnu.tar.gz
           - target: aarch64-unknown-linux-gnu
-            runner: blacksmith-2vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             asset_name: pipette-cli-aarch64-unknown-linux-gnu.tar.gz
             archive: tar.gz
             cross_packages: gcc-aarch64-linux-gnu
@@ -876,7 +876,7 @@ jobs:
             binaries: pipette
             plan_asset_name: pipette-plan-aarch64-unknown-linux-gnu.tar.gz
           - target: aarch64-apple-darwin
-            runner: blacksmith-6vcpu-macos-26
+            runner: macos-26
             asset_name: pipette-cli-aarch64-apple-darwin.tar.gz
             archive: tar.gz
             # pipette-mlx is a pipette-cli dependency (only `pipette` ships), so
@@ -887,7 +887,7 @@ jobs:
             binaries: pipette
             plan_asset_name: pipette-plan-aarch64-apple-darwin.tar.gz
           - target: x86_64-pc-windows-msvc
-            runner: blacksmith-2vcpu-windows-2025
+            runner: windows-2025
             asset_name: pipette-cli-x86_64-pc-windows-msvc.zip
             archive: zip
             packages: pipette-cli pipette-plan
@@ -925,11 +925,11 @@ jobs:
         if: matrix.cross_packages
         run: |
           # Skip `apt-get update` on the fast path: the runner image ships
-          # current indexes and Blacksmith's transparent apt cache serves these
-          # base-pool packages instantly (49 MB in ~0s). A full refresh here
-          # instead blocks ~3min on the un-mirrored security.ubuntu.com repo
-          # (78 kB/s) — the dominant cost of this whole job. Fall back to a
-          # refresh + retry only if the direct install hits a stale index.
+          # current indexes, so these base-pool packages install straight from
+          # them. A full refresh here instead blocks ~3min on the un-mirrored
+          # security.ubuntu.com repo (78 kB/s), which was the dominant cost of
+          # this whole job. Fall back to a refresh and retry only if the direct
+          # install hits a stale index.
           sudo apt-get install -y ${{ matrix.cross_packages }} || {
             sudo apt-get update
             sudo apt-get install -y ${{ matrix.cross_packages }}
@@ -1080,7 +1080,7 @@ jobs:
     # failure arrives here as a graph of skips and the gate reports success.
     needs: [changes, release-metadata, conventions, rust-check, python-check, build-artifact, ios-check, ios-archive, android-app, android-lint]
     if: always()
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Verify all builds succeeded
         run: |
@@ -1103,7 +1103,7 @@ jobs:
     # but does not publish.
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: [release-metadata, build-complete]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Serialize concurrent manual dispatches against the same ref so two
     # clicks don't race each other creating the same release tag.
     concurrency:

--- a/.github/workflows/ios-deadcode.yml
+++ b/.github/workflows/ios-deadcode.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   ios-deadcode:
     name: ios-deadcode
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: macos-26
     continue-on-error: true
     env:
       # Match ios-check's pinned toolchain (see build.yml for the rationale).


### PR DESCRIPTION
> [!IMPORTANT]
> **Ready for review, but do not merge until this repo is public.**
> While `pipette-clients` is private, GitHub-hosted minutes are billable and macOS carries a 10x
> multiplier. There are five macOS jobs, two of which compile llama.cpp. Merging early costs money
> for zero benefit, since forks cannot see a private repo anyway. Merge this immediately **before**
> flipping the repo public.

Part of open-source readiness (CI). Ported from the internal repo, where this change was reviewed
as a single commit; the export carries the same three workflow files, so it transferred without
conflicts.

## Problem

Fork CI does not work today, and no `if:` gate can fix it. Every `runs-on:` in the repo was a
Blacksmith label, and Blacksmith runners are provisioned against the Liquid org account, so a fork
never matches those labels and its jobs **queue indefinitely rather than failing fast**. An outside
contributor's first PR would get no signal whatsoever.

Gating the release workflow so forks don't hit a confusing red run was about exposure. This is
about forks getting usable CI at all.

GitHub Actions minutes are free and unmetered for public repos on standard runners, so once we
flip, the reason to pay for Blacksmith largely goes away.

## Change

All 20 Blacksmith labels swapped, across `build.yml`, `android-release-distribution.yml`, and
`ios-deadcode.yml`:

| Blacksmith | count | GitHub-hosted |
|---|---|---|
| `blacksmith-2vcpu-ubuntu-2404` | 13 | `ubuntu-24.04` |
| `blacksmith-6vcpu-macos-26` | 5 | `macos-26` |
| `blacksmith-2vcpu-windows-2025` | 2 | `windows-2025` |

Covers `runs-on:` lines and `runner:` matrix rows alike. 25 insertions, 25 deletions, no logic
touched.

The `windows-2022` matrix row for `aarch64-pc-windows-msvc` is already GitHub-hosted (Blacksmith
has no arm64 Windows) and is unchanged. It's also the existing precedent that mixed labels work
here.

Pinned OS versions rather than `*-latest`, matching the pins this repo already keeps for
`windows-2022`, `DEVELOPER_DIR`, `sentry-cli` 3.6.0, `firebase-tools` 15.21.0, and Periphery 3.7.4.
A floating label would silently move the toolchain under builds that report `runtime_version` to
the collector.

## Why this is low-risk

**No Blacksmith-specific actions were in use anywhere.** Blacksmith ships drop-in replacements
(`useblacksmith/cache`, `useblacksmith/setup-*`) and this repo uses none of them; every `uses:` is
standard (`actions/cache`, `Swatinem/rust-cache`, `mozilla-actions/sccache-action`, and so on).
Verified by grep before touching anything. So this really is only `runs-on:` labels, with no cache
or setup step changing alongside.

One comment went stale with the labels and is fixed in the same commit. The `apt-get update` skip
in the cross-compilation step justified itself partly on "Blacksmith's transparent apt cache",
which a GitHub-hosted runner does not have. The skip still holds on the reason that survives, that
the runner image ships current indexes and a full refresh blocks ~3min on the un-mirrored
security.ubuntu.com, and the fallback refresh-and-retry still covers a stale index. The step itself
is unchanged.

## Verification

Re-run on this branch rather than carried over from the internal repo:

- **`actionlint` 1.7.12: 0 `runner-label` findings**, with `shellcheck` unchanged at 12. Zero
  confirms every new label resolves to a real GitHub-hosted runner. Stronger than grep: a typo'd
  `macos-2026` would pass grep and fail actionlint. The 12 shellcheck findings are all info-level
  and sit on lines this branch does not touch.
- All three workflows still parse as YAML with the expected job counts (12 / 1 / 1).
- Zero `blacksmith` references remain anywhere under `.github/` or `ci/`.
- **Not verified:** actual runtime on GitHub-hosted runners in this repo. Upstream, a full-matrix
  run on the new labels came back 18 passed and 1 skipped, with `macos-26`, `ubuntu-24.04` and
  `windows-2025` in the check names across all six `build-artifact` targets, three `rust-check`
  hosts and both Android jobs. Because changing workflow files trips every path filter, that run
  covered `ios-archive`, `ios-check` and `python-check` rather than a filtered subset.

## Known cost, accepted

The five macOS jobs drop from 6 vCPU to standard `macos-26`, and `ios-check` / `ios-archive`
compile llama.cpp, so expect them to get slower. sccache plus `actions/cache` should absorb part of
it. Worth measuring after the flip rather than guessing now.

Also worth watching post-flip: GitHub's free tier caps concurrent macOS jobs for public repos (5 on
the free plan) and this repo has exactly five, so a full matrix run may serialize. The org is on an
enterprise plan so the ceiling may be higher.

## Considered and rejected

Conditional labels (`github.repository == '...' && 'blacksmith-...' || 'ubuntu-24.04'`) would have
fixed fork CI today with no billing change and no dependency on the flip, but it means that
expression in 20 places including matrix rows. The permanent YAML complexity isn't worth it.
