### PR TITLE
fix: report the published release version as client_version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -520,6 +520,16 @@ jobs:
       - name: Archive iOS app (Release, unsigned, private-thermal)
         env:
           PIPETTE_SKIP_BUILD_LLAMA: "1"
+          # Read by the `Stamp git commit` build phase (ios/stamp-git-commit.sh),
+          # which writes it into the BUILT Info.plist as `PipetteBuildVersion`.
+          # Without it the archive carried only the project's hardcoded
+          # CFBundleVersion `1`, so `client_version` named the release nowhere —
+          # the version below reached the asset's filename and stopped there.
+          #
+          # Unconditional, unlike the Rust/Android equivalents: xcodebuild
+          # recompiles this archive from scratch every run regardless (see the
+          # DerivedData cache note above), so there is no cache to protect.
+          PIPETTE_BUILD_VERSION: ${{ needs.release-metadata.outputs.version }}
         run: |
           xcodebuild archive \
             -project ios/Pipette/Pipette.xcodeproj \
@@ -621,9 +631,25 @@ jobs:
 
   android-app:
     name: android-app
-    needs: [changes]
+    needs: [changes, release-metadata]
     if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-24.04
+    env:
+      # The APK this job uploads is the one github-release publishes, and
+      # `BuildConfig.BUILD_VERSION` is what it submits as `client_version`. With
+      # nothing injected, build.gradle.kts falls back to "dev" — every release
+      # reporting the same thing as every local build.
+      #
+      # Same release-path-only gating as PIPETTE_CLI_BUILD_VERSION below: the
+      # version changes every commit and lands in BuildConfig, so injecting it
+      # on ordinary CI runs would defeat the gradle build cache for no gain.
+      #
+      # PIPETTE_VERSION_CODE is deliberately NOT set here. It is the
+      # Play/Firebase monotonic counter owned by android-release-distribution
+      # .yml, and setting it is what makes build.gradle.kts treat the build as
+      # an official distribution (verifyReleaseSentryDsn would then fail this
+      # job on a fork with no SENTRY_DSN secret).
+      PIPETTE_BUILD_VERSION: ${{ startsWith(github.ref, 'refs/heads/release/') && needs.release-metadata.outputs.version || '' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -816,12 +842,17 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.runner }}
     env:
-      # The real date+sha version changes every commit, so on CI (push/PR) runs
-      # it would invalidate the crate that bakes it in via `env!` on each
-      # build. Use it only on the release path (workflow_dispatch — see
-      # github-release) and fall back to build.rs's own "dev" default otherwise,
-      # keeping the crate cacheable.
-      PIPETTE_CLI_BUILD_VERSION: ${{ github.event_name == 'workflow_dispatch' && needs.release-metadata.outputs.version || 'dev' }}
+      # The real date+sha version changes every commit, so on ordinary CI (PR /
+      # main push) runs it would invalidate the crate that bakes it in via
+      # `env!` on each build. Use it only on the release path and fall back to
+      # build.rs's own "dev" default otherwise, keeping the crate cacheable.
+      #
+      # The release path is a PUSH to `release/**` — that is what github-release
+      # gates on, so gating this on workflow_dispatch alone shipped every
+      # released binary reporting `0.1.0 (build dev)` as its `--version` and its
+      # `client_version`. The two conditions must name the same event or the
+      # published artifact does not know what it is.
+      PIPETTE_CLI_BUILD_VERSION: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/heads/release/')) && needs.release-metadata.outputs.version || 'dev' }}
       # Compiler-level cache: reuse unchanged compilation units (including
       # workspace crates, which the target-dir cache drops) across runs. Biggest
       # effect on the CPU-bound Windows targets.

--- a/android/Pipette/app/build.gradle.kts
+++ b/android/Pipette/app/build.gradle.kts
@@ -174,14 +174,26 @@ val posthogHost = localOrEnv("posthog.host", "POSTHOG_HOST").orEmpty().ifBlank {
 //              GitHub triggers by renaming the workflow file; see that
 //              workflow's "Resolve build identity" step for the bump rule.
 //   env (CI):  PIPETTE_BUILD_TAG. Short commit tag (e.g. "g7d2a7f6") appended
-//              to the base version as "1.0+g7d2a7f6". The commit, not a build
-//              counter, is the harness identity: this string is submitted as
-//              `client_version`, where two builds of one commit are the same
-//              harness and should group together.
-// Uninjected/local builds fall back to versionCode 1 / versionName "1.0".
+//              to the base version as "1.0+g7d2a7f6", so the user-visible
+//              version names the commit it was cut from.
+//   env (CI):  PIPETTE_BUILD_VERSION. The version this build is PUBLISHED as —
+//              ci/version.sh's output, which is also the GitHub release's tag
+//              and name (e.g. "2026.08.1-3-ga1b2c3d4ab"). Surfaces as
+//              BuildConfig.BUILD_VERSION and is submitted verbatim as
+//              `client_version`, so a warehouse row maps to a downloadable
+//              release by equality rather than by anyone's parsing rule.
+// Uninjected/local builds fall back to versionCode 1 / versionName "1.0" /
+// BUILD_VERSION "dev".
 val baseVersionName = localOrEnv("pipette.versionName", "PIPETTE_VERSION_NAME") ?: "1.0"
 val ciVersionCode = localOrEnv("pipette.versionCode", "PIPETTE_VERSION_CODE")?.toIntOrNull()
 val ciBuildTag = localOrEnv("pipette.buildTag", "PIPETTE_BUILD_TAG")?.takeIf { it.isNotBlank() }
+
+// Kept off versionName deliberately. versionName is user-visible and, on the
+// Play path, constrained by what the store will accept; `client_version` wants
+// the release string untouched. Two fields, so neither has to compromise.
+// "dev" matches what the Rust client's build.rs defaults to, so a local build of
+// either reads the same way in the warehouse.
+val buildVersion = localOrEnv("pipette.buildVersion", "PIPETTE_BUILD_VERSION")?.takeIf { it.isNotBlank() } ?: "dev"
 
 // Real release keystore, if configured (local.properties / env); otherwise null and
 // the release build falls back to the shared debug keystore (see buildTypes.release).
@@ -266,11 +278,16 @@ android {
         targetSdk = 36
         // Monotonic when CI injects PIPETTE_VERSION_CODE (base + run number);
         // otherwise 1 for local/uninjected builds. versionName is deliberately
-        // NOT derived from it: it ships as `client_version`, which wants the
-        // commit, and a run-number reset would otherwise make that key ambiguous
-        // as well as colliding the code. Local builds keep the bare base version.
+        // NOT derived from it: a run-number reset would make it ambiguous as
+        // well as colliding the code. Local builds keep the bare base version.
         versionCode = ciVersionCode ?: 1
         versionName = ciBuildTag?.let { "$baseVersionName+$it" } ?: baseVersionName
+
+        // The published release this APK is, submitted verbatim as
+        // `client_version` (see LocalStorage.kt). The release build type takes
+        // it as-is; debug appends "-debug" below, mirroring versionNameSuffix,
+        // so a developer's submissions stay distinguishable from a release's.
+        buildConfigField("String", "BUILD_VERSION", "\"$buildVersion\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         ndk {
@@ -337,6 +354,11 @@ android {
             // guard compares getProcessName() to the runtime packageName, so it still holds.
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
+            // The `client_version` counterpart of versionNameSuffix above: that
+            // suffix no longer reaches the wire, since client_version is
+            // BUILD_VERSION rather than VERSION_NAME. Without this a debug
+            // build of a release commit would submit as that release.
+            buildConfigField("String", "BUILD_VERSION", "\"$buildVersion-debug\"")
             signingConfig = signingConfigs.getByName("debug")
             // Sentry environment (read by io.sentry.environment in the manifest): keep
             // dev/test crashes + feedback out of the production environment. Mirrors the

--- a/android/Pipette/app/src/main/java/ai/liquid/pipette/LocalStorage.kt
+++ b/android/Pipette/app/src/main/java/ai/liquid/pipette/LocalStorage.kt
@@ -216,11 +216,15 @@ class LocalStorage(private val context: Context) : JobStore {
     json.put("submitted_at", DateFormats.isoNow())
     // This app build — the harness, not the engine it drove (runtime_version).
     // The server stores it opaquely as a grouping key, so a shift in the numbers
-    // can be attributed to an app change rather than to the device. VERSION_NAME
-    // alone is the whole identity here: CI folds the version code into it and
-    // debug builds carry a `-debug` suffix, so unlike iOS there is no separate
-    // build number worth appending.
-    json.put("client_version", BuildConfig.VERSION_NAME)
+    // can be attributed to an app change rather than to the device.
+    //
+    // BUILD_VERSION, not VERSION_NAME: this is the version the APK was PUBLISHED
+    // as (ci/version.sh, e.g. "2026.08.1-3-ga1b2c3d4ab"), which is also the
+    // GitHub release's tag — so a row maps to a downloadable artifact by
+    // equality. VERSION_NAME is the user-visible app version and is constrained
+    // by what Play accepts; it cannot also be this. "dev" on a local build,
+    // "<version>-debug" on a debug build. See app/build.gradle.kts.
+    json.put("client_version", BuildConfig.BUILD_VERSION)
     json.put("runtime_name", "llamacpp_apk_pipette")
     json.put("runtime_version", runtimeVersion)
     json.put("runtime_descriptor", SubmissionRef.runtime(runtimeVersion))

--- a/android/Pipette/app/src/test/java/ai/liquid/pipette/LocalStoragePayloadTest.kt
+++ b/android/Pipette/app/src/test/java/ai/liquid/pipette/LocalStoragePayloadTest.kt
@@ -76,8 +76,10 @@ class LocalStoragePayloadTest {
     assertEquals("""{"readiness":{"max_wait_secs":180,"skip_thermal":false}}""", payload.getString("benchmark_flags"))
 
     // The app build that produced the run — distinct from runtime_version
-    // above, which names the engine it drove.
-    assertEquals(BuildConfig.VERSION_NAME, payload.getString("client_version"))
+    // above, which names the engine it drove. BUILD_VERSION is the release this
+    // APK was published as (ci/version.sh, matching the GitHub release tag), NOT
+    // the user-visible VERSION_NAME; the two are deliberately separate fields.
+    assertEquals(BuildConfig.BUILD_VERSION, payload.getString("client_version"))
 
     // Retired server-side.
     assertFalse("mmproj_quant must not be emitted", payload.has("mmproj_quant"))

--- a/crates/pipette-cli/src/lib.rs
+++ b/crates/pipette-cli/src/lib.rs
@@ -14,20 +14,25 @@
 /// This build's identity, reported to the management server as
 /// `client_version` on every submission and printed by `pipette --version`.
 ///
-/// Deliberately the *same* string in both places: the warehouse column exists
-/// so a shift in the numbers can be attributed to a harness change, and that
-/// attribution starts from someone pasting what `--version` printed. A second,
-/// tidier spelling for the wire would break that match for nothing — the server
-/// stores the value opaquely and never parses it.
+/// Verbatim the version the release was published under — `ci/version.sh`'s
+/// output, which is also the GitHub release's tag and name, e.g.
+/// `2026.08.1-0-g58c2adbf16`. One string, so a warehouse row maps to a
+/// downloadable release by equality and not by anyone's parsing rule.
 ///
-/// Local builds report `dev` as the build component (see `build.rs`), so a
-/// developer's submissions are distinguishable from a released build's.
-pub const CLIENT_VERSION: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    " (build ",
-    env!("PIPETTE_CLI_BUILD_VERSION"),
-    ")"
-);
+/// The crate's `CARGO_PKG_VERSION` is deliberately *not* part of it. It has
+/// never moved off `0.1.0` and nothing releases on it, so prefixing it made
+/// every row read `0.1.0 (build …)` — a constant in front of the only part that
+/// identified anything, and not a string that matches any release page.
+///
+/// Deliberately the *same* string the wire gets and `--version` prints: the
+/// column exists so a shift in the numbers can be attributed to a harness
+/// change, and that attribution starts from someone pasting what `--version`
+/// printed. A second, tidier spelling for the wire would break that match for
+/// nothing — the server stores the value opaquely and never parses it.
+///
+/// Local builds report `dev` (see `build.rs`), so a developer's submissions are
+/// distinguishable from a released build's.
+pub const CLIENT_VERSION: &str = env!("PIPETTE_CLI_BUILD_VERSION");
 
 pub mod artifact_ref;
 pub(crate) mod benchmarks;

--- a/crates/pipette-cli/src/results/record.rs
+++ b/crates/pipette-cli/src/results/record.rs
@@ -338,13 +338,19 @@ mod tests {
         assert_eq!(wire["client_version"], crate::CLIENT_VERSION);
 
         // Comparing against the const alone would be the code checking itself,
-        // so pin the shape too: a value that lost its build component (or was
-        // empty) would still satisfy the equality above.
+        // so pin the shape too: an empty value would still satisfy the equality
+        // above. The value is the release's own version string (`ci/version.sh`,
+        // e.g. "2026.08.1-0-g58c2adbf16") or "dev" for a local build — nothing
+        // is wrapped around it, since the point is that it equals the GitHub
+        // release name rather than merely containing it.
         let reported = wire["client_version"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("client_version must be a string"))?;
-        assert!(reported.starts_with(env!("CARGO_PKG_VERSION")));
-        assert!(reported.contains("(build "));
+        assert!(!reported.is_empty());
+        assert!(
+            !reported.contains(char::is_whitespace),
+            "client_version must be the bare release version, got {reported:?}"
+        );
         Ok(())
     }
 

--- a/crates/pipette-plan/src/lib.rs
+++ b/crates/pipette-plan/src/lib.rs
@@ -1,13 +1,10 @@
-/// Driver version, `<crate> (build <stamp>)` — the same shape the client
-/// reports, so `--version` output from either is directly comparable. Which
-/// plan features parse is a function of this value: a transport added after a
-/// release cannot be read by that release's driver.
-pub const PLAN_VERSION: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    " (build ",
-    env!("PIPETTE_CLI_BUILD_VERSION"),
-    ")"
-);
+/// Driver version — the release this driver was published in, verbatim (e.g.
+/// `2026.08.1-0-g58c2adbf16`), or `dev` for a local build. The same string the
+/// client reports, so `--version` output from either is directly comparable and
+/// both name the same GitHub release. Which plan features parse is a function of
+/// this value: a transport added after a release cannot be read by that
+/// release's driver.
+pub const PLAN_VERSION: &str = env!("PIPETTE_CLI_BUILD_VERSION");
 
 pub mod capability_rules;
 pub mod cli;

--- a/ios/Pipette/Pipette/Config/Bundle+Pipette.swift
+++ b/ios/Pipette/Pipette/Config/Bundle+Pipette.swift
@@ -15,20 +15,6 @@ extension Bundle {
         return value
     }
 
-    /// "<short version>[-internal] (<build>[, <commit>])" — e.g. "0.1.0 (1, a1b2c3d)", or
-    /// "0.1.0-internal (1)" for an internal build with no git metadata. Shared by the
-    /// Settings debug row, the Sentry `app_version` tag, and the `client_version` on every
-    /// submitted result, so the displayed version and the reported version can never drift.
-    ///
-    /// The commit is what makes the string identifying: `CFBundleVersion` is `1` on every
-    /// local build, so without it two results from different source trees are
-    /// indistinguishable in the warehouse.
-    ///
-    /// The `-internal` marker is here rather than in a separate field because this string is
-    /// already the one thing that reaches all of them: a result gated by a real die
-    /// temperature is not comparable to one gated by `thermalState`, and without the
-    /// marker two such rows are indistinguishable. `client_version` is free-form
-    /// upstream (`Option<String>`), so the suffix breaks no parser.
     /// The commit this build was made from, stamped into the built Info.plist by
     /// `ios/stamp-git-commit.sh` — `"a1b2c3d"`, or `"a1b2c3d-dirty"` when the tree carried
     /// uncommitted changes. Nil when the build had no git metadata to read, which
@@ -37,7 +23,36 @@ extension Bundle {
         normalizedInfoString("PipetteGitCommit")
     }
 
+    /// The version this build publishes as — `ci/version.sh`'s output, stamped into the built
+    /// Info.plist by `ios/stamp-git-commit.sh` when CI passes `PIPETTE_BUILD_VERSION`
+    /// (e.g. `"2026.08.1-3-ga1b2c3d4ab"`). Also the GitHub release's tag and name, which is the
+    /// point: a submitted row names a downloadable artifact.
+    ///
+    /// Nil on a local build and on the TestFlight path, neither of which has a release to name.
+    ///
+    /// Not `CFBundleVersion`: that key is the build *number*, hardcoded to `1` in the project,
+    /// stamped by `agvtool` only on the TestFlight path, and validated by App Store Connect —
+    /// so it can neither carry this value nor be replaced by it.
+    var buildVersion: String? {
+        normalizedInfoString("PipetteBuildVersion")
+    }
+
+    /// A released build reports the release, verbatim: `"2026.08.1-3-ga1b2c3d4ab-internal"`.
+    /// Anything else falls back to the composed local form, `"0.1.0 (1, a1b2c3d)"`.
+    ///
+    /// The release string is not wrapped in the marketing version and build number. Those add
+    /// nothing a release has to say — `MARKETING_VERSION` has never moved off `0.1.0` and
+    /// `CFBundleVersion` is `1` — and wrapping them around it would stop the value matching the
+    /// release page it came from. It already ends in the commit, so nothing identifying is lost.
+    ///
+    /// The `-internal` suffix survives because it is not version metadata: a result gated by a
+    /// real die temperature is not comparable to one gated by `thermalState`, and without the
+    /// marker two such rows are indistinguishable. `client_version` is free-form upstream
+    /// (`Option<String>`), so the suffix breaks no parser.
     var appVersionDisplayString: String {
+        if let buildVersion {
+            return "\(buildVersion)\(BuildFlavor.versionSuffix)"
+        }
         let version = object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
         let build = object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
         return Self.appVersionDisplayString(version: version, build: build, commit: gitCommit)

--- a/ios/Pipette/PipetteTests/AppVersionStringTests.swift
+++ b/ios/Pipette/PipetteTests/AppVersionStringTests.swift
@@ -37,4 +37,33 @@ struct AppVersionStringTests {
     @Test func anUnresolvedPlaceholderReadsAsAbsent() {
         #expect(Bundle.main.normalizedInfoString("PipetteGitCommitAbsentForTests") == nil)
     }
+
+    /// A local build has no release to name, so `PipetteBuildVersion` is absent and the
+    /// composed form above is what gets reported. The test host is such a build, which is what
+    /// makes this the branch exercised here.
+    @Test func anAbsentBuildVersionLeavesTheComposedForm() {
+        #expect(Bundle.main.buildVersion == nil)
+        #expect(Bundle.main.appVersionDisplayString.hasSuffix(")"))
+    }
+
+    /// A released build reports the release verbatim — the tag `github-release` published, so a
+    /// warehouse row and a downloadable artifact match by string equality. Nothing is wrapped
+    /// around it: `MARKETING_VERSION` is a constant `0.1.0` and `CFBundleVersion` a constant
+    /// `1`, so prefixing them would only stop the value matching the release page.
+    ///
+    /// Pinned as a literal rather than by re-running the composition, so a change to how the
+    /// string is built has to restate the contract rather than silently redefine it.
+    @Test func aStampedReleaseVersionIsReportedVerbatim() {
+        let stamped = "2026.08.1-3-ga1b2c3d4ab"
+        #expect(
+            "\(stamped)\(BuildFlavor.versionSuffix)"
+                == (BuildFlavor.isInternal ? "2026.08.1-3-ga1b2c3d4ab-internal" : stamped))
+    }
+
+    /// The internal marker is the one thing carried into the release string. It is not version
+    /// metadata: a result gated by a real die temperature is not comparable to one gated by
+    /// `thermalState`, and `client_version` is where that distinction is recorded.
+    @Test func theInternalMarkerSurvivesTheReleaseVersion() {
+        #expect(BuildFlavor.versionSuffix == (BuildFlavor.isInternal ? "-internal" : ""))
+    }
 }

--- a/ios/stamp-git-commit.sh
+++ b/ios/stamp-git-commit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# Stamp the app's git commit into the built Info.plist, so a submitted result can
-# be traced to the source that produced it.
+# Stamp this build's identity — the git commit, and on CI the release version —
+# into the built Info.plist, so a submitted result can be traced to the source
+# and the build that produced it.
 #
 # Runs as the last build phase — after "Process Info.plist", whose output this
 # rewrites. Nothing under source control changes.
@@ -14,17 +15,41 @@
 # commit, forever. The built Info.plist is a build artifact, so stamping it costs
 # no churn.
 #
-# The key is absent, not empty, when it cannot be resolved (no git, no repo, an
-# export from a tarball). `Bundle.normalizedInfoString` already treats an absent
-# or placeholder value as "unknown", so the app degrades to reporting the version
-# alone rather than reporting a lie.
+# Both keys are absent, not empty, when they cannot be resolved (no git, no repo,
+# an export from a tarball; a local build with no CI version).
+# `Bundle.normalizedInfoString` already treats an absent or placeholder value as
+# "unknown", so the app degrades to reporting what it does know rather than
+# reporting a lie.
 set -euo pipefail
 
-KEY=PipetteGitCommit
 PLIST="${TARGET_BUILD_DIR:?must run as an Xcode build phase}/${INFOPLIST_PATH:?}"
 
+# stamp <key> <value> — replace-or-add, since "Process Info.plist" may have
+# already written the key from the source plist.
+stamp() {
+    /usr/libexec/PlistBuddy -c "Delete :$1" "$PLIST" 2>/dev/null || true
+    /usr/libexec/PlistBuddy -c "Add :$1 string $2" "$PLIST"
+    echo "note: $1 = $2"
+}
+
+# The version this build publishes as (ci/version.sh), injected by the
+# ios-archive CI job. This is what reaches the management server as
+# `client_version`, so an archive attached to a release names that release.
+#
+# A separate key rather than CFBundleVersion: that one is a build *number*, is
+# validated by App Store Connect, and on the TestFlight path is already owned by
+# ci_scripts/ci_pre_xcodebuild.sh (`agvtool new-version` with $CI_BUILD_NUMBER).
+# Overloading it with "2026.08.1-3-ga1b2c3d4ab" would collide with that and put a
+# non-conforming value in front of App Review. `PipetteBuildVersion` is ours, so
+# it is free-form — as `client_version` upstream already is.
+if [[ -n "${PIPETTE_BUILD_VERSION:-}" ]]; then
+    stamp PipetteBuildVersion "$PIPETTE_BUILD_VERSION"
+else
+    echo "note: PIPETTE_BUILD_VERSION unset — PipetteBuildVersion left unset (local build)"
+fi
+
 if ! commit=$(git -C "$SRCROOT" rev-parse --short HEAD 2>/dev/null); then
-    echo "note: no git metadata — $KEY left unset"
+    echo "note: no git metadata — PipetteGitCommit left unset"
     exit 0
 fi
 
@@ -34,6 +59,4 @@ if ! git -C "$SRCROOT" diff --quiet HEAD 2>/dev/null; then
     commit="$commit-dirty"
 fi
 
-/usr/libexec/PlistBuddy -c "Delete :$KEY" "$PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :$KEY string $commit" "$PLIST"
-echo "note: $KEY = $commit"
+stamp PipetteGitCommit "$commit"


### PR DESCRIPTION
**Problem**
`client_version` on every submitted result was a placeholder on all three released clients. `ci/version.sh`'s output reached the GitHub release tag and the artifact filenames, but never the builds themselves, so released rows reported `0.1.0 (build dev)` (CLI), `1.0` (APK) and `0.1.0-internal (1, <sha>)` (iOS).

**Solution**
- Injects the release version on pushes to `release/**`, the event `github-release` publishes from; it was gated on `workflow_dispatch` alone, which never fires on the release path
- Reports that version verbatim as `client_version`, dropping the wrappers around it so a row and a release match by string equality
- Adds `BuildConfig.BUILD_VERSION` on Android, leaving the user-visible `versionName` free to stay Play-compatible
- Stamps `PipetteBuildVersion` into the built iOS `Info.plist`, since `CFBundleVersion` is App Store validated and owned by `agvtool` on the TestFlight path
- Keeps the `-internal` marker on iOS and appends `-debug` on Android debug builds

**Testing**
- `cargo test -p pipette-cli` passes; `pipette --version` prints `2026.08.1-0-g58c2adbf16` when injected, `dev` otherwise
- Android `BuildConfig.java` verified for release-injected, release-uninjected and debug; `LocalStoragePayloadTest` passes
- The iOS stamp script was exercised against a real `Info.plist`; the Swift changes are unverified locally and rely on `ios-check`
