### PR TITLE
ci: cache Gradle properly and stop storing three copies of every cache

### DIFF
--- a/.github/workflows/android-release-distribution.yml
+++ b/.github/workflows/android-release-distribution.yml
@@ -293,8 +293,22 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      # The Gradle cache the CI android-app job uses, for the same reason: this
+      # job otherwise resolved every plugin and dependency from cold Maven.
+      # cache-provider is pinned to 'basic' so the cache stays on the GitHub
+      # Actions cache rather than the commercial service the action defaults to.
+      # See build.yml's android-app for the full note.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
+
       - name: Set up Android SDK
+        # platform-tools alone: the action's default `tools platform-tools`
+        # drags in the Android Emulator, which this job never boots.
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        with:
+          packages: platform-tools
 
       - name: Install Android NDK + native build tools
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,16 @@ jobs:
           # rust-cache drops by default; cargo fingerprinting still recompiles
           # any crate whose sources changed, so no stale artifacts.
           cache-workspace-crates: true
+          # Only main writes. Restore is unchanged, every branch still reads
+          # main's entry; this just stops a branch that missed from saving its
+          # own copy under its own ref. That is how the repo ended up holding
+          # rust-check-linux-v3 twice at 782 MB, and three more entries twice
+          # over, against a 10 GB ceiling. Cost: the first PR after a Cargo.lock
+          # bump compiles cold, because the refreshed entry only lands once the
+          # bump reaches main. Worth it while eviction is the binding
+          # constraint, since a warm cache that gets evicted is worth less than
+          # a slightly staler one that survives.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Format
         if: matrix.fmt
@@ -742,6 +752,8 @@ jobs:
         with:
           key: android-app-v1
           cache-bin: false
+          # Only main writes; see the note on rust-check's rust-cache above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # sccache caches the llama.cpp/ggml C/C++ cross-compile (the bulk of the
       # gradle build), routed in via build-rust-android.sh's compiler launchers.
@@ -1073,6 +1085,8 @@ jobs:
           key: build-artifact-${{ matrix.asset_name }}-v3
           cache-bin: false
           cache-workspace-crates: true
+          # Only main writes; see the note on rust-check's rust-cache above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Per-target clippy, only where it covers a rust-check blind spot
       # (target_clippy entries): the android target lints target_os="android"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -783,6 +783,20 @@ jobs:
           # Enables sccache's GHA backend for the native compiles (see the
           # compiler launchers in build-rust-android.sh).
           SCCACHE_GHA_ENABLED: "true"
+          # Diagnostic, temporary. sccache reports a write failure only as a
+          # counter in `--show-stats`; the reason goes to its server log, which
+          # is off by default. This job needs that reason: it has been recording
+          # 0% cache hits with writes failing, 336 of 336 on the main push in run
+          # 31493653710, and because GitHub scopes cache reads to your own ref
+          # plus the default branch, main failing to write is what leaves every
+          # other ref with no Android objects to restore. `warn` is enough to
+          # capture the backend error without logging a line per cache key.
+          #
+          # These must sit on this step rather than at job level: the sccache
+          # server is started lazily by the first client call, which happens
+          # here, and it captures the environment it was started with.
+          SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-error.log
+          SCCACHE_LOG: warn
         # assemble first so the APKs exist even if a later unit test fails (the job
         # still goes red, but the artifacts are uploaded for inspection). Release is
         # signed with the real release keystore when configured (RELEASE_* secrets),
@@ -790,6 +804,18 @@ jobs:
         # assembleRelease runs the PIP-391 guard (verifyReleaseClerkKey, see build.gradle.kts):
         # the release APK must ship a usable Clerk publishable key or the build fails fast.
         run: ./gradlew :app:assembleDebug :app:assembleRelease :app:testDebugUnitTest --no-daemon --stacktrace
+
+      # Companion to SCCACHE_ERROR_LOG above, and temporary with it. `always()`
+      # because a red build is exactly when the log is worth reading, and
+      # if-no-files-found: ignore because sccache only creates the file when it
+      # has something to say.
+      - name: Upload sccache server log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: sccache-error-log-android-app
+          path: ${{ runner.temp }}/sccache-error.log
+          if-no-files-found: ignore
 
       - name: Verify computed native libs 16 KB page-size compatibility
         working-directory: android/Pipette

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -377,15 +377,21 @@ jobs:
       # pattern returns. Note this variable also implies SCCACHE_GHA_ENABLED,
       # which is why it is set per-step beside it rather than workflow-wide.
       #
-      # SCCACHE_GHA_RW_MODE keeps writes on main, matching every other cache
-      # here. Objects written from a PR ref are visible to nothing else and are
-      # dropped with the PR: two runs of this branch alone left 958 of them.
-      # main seeds, every other ref reads.
+      # Deliberately NOT paired with SCCACHE_GHA_RW_MODE: READ_ONLY off main.
+      # Every other cache here is main-writes-only, and sccache was tried the
+      # same way and measured worse. It is the opposite shape: many small
+      # objects rather than one blob, so a PR's copy holds only what that PR
+      # compiled instead of duplicating main's, and it is what lets a second run
+      # on the same PR reuse the first (android-app's native build went 8m10s
+      # cold to 2m37s warm that way). Restricting it cost roughly ten minutes
+      # per PR run across the iOS and Android jobs to reclaim 239 MB, 2.4% of
+      # the ceiling, in entries GitHub deletes when the PR closes. It also
+      # pinned cache_write_errors at one-per-object on every non-main run, which
+      # is the counter used to detect the poisoning described above.
       - name: Build llama.cpp (static lib + bindings)
         env:
           SCCACHE_GHA_ENABLED: "true"
           SCCACHE_GHA_VERSION: "2"
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh sim
 
       # Regenerate Generated/MLX/MLXBuildInfo.swift from Package.resolved (the
@@ -525,7 +531,6 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
           # See the note on ios-check's build-llama step.
           SCCACHE_GHA_VERSION: "2"
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh device
 
       - name: Generate MLX build info
@@ -809,7 +814,6 @@ jobs:
           # See the note on ios-check's build-llama step. This is the job whose
           # v1 namespace was poisoned, so it is the one v2 is meant to rescue.
           SCCACHE_GHA_VERSION: "2"
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
           # Diagnostic, temporary. sccache reports a write failure only as a
           # counter in `--show-stats`; the reason goes to its server log, which
           # is off by default. This job needs that reason: it has been recording
@@ -986,7 +990,6 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       # See the note on ios-check's build-llama step.
       SCCACHE_GHA_VERSION: "2"
-      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       RUSTC_WRAPPER: sccache
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,9 +363,29 @@ jobs:
       # backed by the GHA cache via SCCACHE_GHA_ENABLED. Swift sources compiled
       # later by xcodebuild can't use sccache, but the app target has no
       # C/C++/ObjC sources of its own.
+      # The two SCCACHE_GHA_* settings below are repeated at every sccache step
+      # in this repo; this is the copy that carries the reasoning.
+      #
+      # SCCACHE_GHA_VERSION selects the namespace every object is keyed into,
+      # and bumping it abandons the previous one. v2 exists because v1's
+      # android-app objects became unwritable: the main push in run 31493653710
+      # recorded 336 write errors against 336 objects, every one an HTTP 409
+      # `already_exists` from CreateCacheEntry, while that same run read-missed
+      # all 336. An entry a write collides with but a read cannot find is one
+      # that was reserved and never finalized, so those keys were poisoned for
+      # good and no later run on main could reseed them. Bump again if that
+      # pattern returns. Note this variable also implies SCCACHE_GHA_ENABLED,
+      # which is why it is set per-step beside it rather than workflow-wide.
+      #
+      # SCCACHE_GHA_RW_MODE keeps writes on main, matching every other cache
+      # here. Objects written from a PR ref are visible to nothing else and are
+      # dropped with the PR: two runs of this branch alone left 958 of them.
+      # main seeds, every other ref reads.
       - name: Build llama.cpp (static lib + bindings)
         env:
           SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_VERSION: "2"
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh sim
 
       # Regenerate Generated/MLX/MLXBuildInfo.swift from Package.resolved (the
@@ -503,6 +523,9 @@ jobs:
       - name: Build llama.cpp (static lib + bindings, device slice)
         env:
           SCCACHE_GHA_ENABLED: "true"
+          # See the note on ios-check's build-llama step.
+          SCCACHE_GHA_VERSION: "2"
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh device
 
       - name: Generate MLX build info
@@ -783,6 +806,10 @@ jobs:
           # Enables sccache's GHA backend for the native compiles (see the
           # compiler launchers in build-rust-android.sh).
           SCCACHE_GHA_ENABLED: "true"
+          # See the note on ios-check's build-llama step. This is the job whose
+          # v1 namespace was poisoned, so it is the one v2 is meant to rescue.
+          SCCACHE_GHA_VERSION: "2"
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
           # Diagnostic, temporary. sccache reports a write failure only as a
           # counter in `--show-stats`; the reason goes to its server log, which
           # is off by default. This job needs that reason: it has been recording
@@ -957,6 +984,9 @@ jobs:
       # workspace crates, which the target-dir cache drops) across runs. Biggest
       # effect on the CPU-bound Windows targets.
       SCCACHE_GHA_ENABLED: "true"
+      # See the note on ios-check's build-llama step.
+      SCCACHE_GHA_VERSION: "2"
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       RUSTC_WRAPPER: sccache
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -661,19 +661,57 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-          # Persists ~/.gradle (dependency cache + the local build cache enabled
-          # in gradle.properties) across runs, keyed on the gradle lockfiles.
-          cache: gradle
+
+      # Persists ~/.gradle (dependency cache, artifact transforms, and the local
+      # build cache enabled in gradle.properties) across runs. Gradle's own
+      # action rather than setup-java's `cache: gradle`, which its docs say not
+      # to combine with. Two reasons beyond it being the official action:
+      #
+      #   - cache-read-only defaults to true off the default branch, so PR runs
+      #     restore main's entry and write nothing. setup-java's actions/cache
+      #     wrote a fresh branch-scoped copy on every run, which is why this repo
+      #     was holding three byte-identical ~1 GB copies of this cache (main,
+      #     release/2026.08.1, refs/pull/4/merge) against a 10 GB ceiling, and
+      #     paying 16-18s per run in the post step to upload each one.
+      #   - It prunes to what the build actually used rather than re-uploading a
+      #     monolithic tarball.
+      #
+      # cache-provider is pinned because the default ('enhanced') routes the
+      # cache through a commercial third-party service; 'basic' keeps it on the
+      # GitHub Actions cache, matching what setup-java did.
+      #
+      # Not wired yet: cache-encryption-key, which is what would let the Gradle
+      # configuration cache survive across runs (this job stores an entry every
+      # run and then reports none available on the next). It needs a repo secret.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
 
       - name: Set up Android SDK
         # Installs cmdline-tools and accepts licenses; AGP auto-downloads the
         # compileSdk platform + build-tools on first build.
+        #
+        # packages: the action's default is `tools platform-tools`, and the
+        # legacy `tools` package pulls the Android Emulator in as a dependency
+        # (~14s of this step). Nothing in CI boots an emulator, so ask for
+        # platform-tools alone.
         uses: android-actions/setup-android@v3
+        with:
+          packages: platform-tools
 
       # Cache the pinned NDK so sdkmanager restores it instead of re-downloading
       # (~1 GB) each run; on a hit the install below is a no-op verify.
-      - name: Cache Android NDK
-        uses: actions/cache@v4
+      #
+      # Restore everywhere, save only on main. The key is content-invariant (it
+      # names an exact NDK version), so a branch can never hold anything main
+      # does not already have. On a miss, though, actions/cache would save a
+      # branch-scoped copy anyway, and this repo accumulated three identical
+      # 589 MB copies that way. Splitting restore from save means PR and release
+      # branches read main's entry and never write one.
+      - name: Restore Android NDK
+        id: ndk-cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ANDROID_HOME }}/ndk/27.2.12479018
           key: android-ndk-27.2.12479018-${{ runner.os }}
@@ -685,6 +723,15 @@ jobs:
           yes | sdkmanager --install "ndk;27.2.12479018" >/dev/null
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ninja-build cmake
+
+      # Seed the entry every other branch restores from. Only on main, and only
+      # when the restore above missed; see the restore step for why.
+      - name: Save Android NDK
+        if: github.ref == 'refs/heads/main' && steps.ndk-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.ANDROID_HOME }}/ndk/27.2.12479018
+          key: android-ndk-27.2.12479018-${{ runner.os }}
 
       - name: Install Rust (Android target)
         uses: dtolnay/rust-toolchain@stable
@@ -824,10 +871,25 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      # This job had no Gradle cache at all, so every run resolved the whole
+      # plugin and dependency graph from cold Maven: ~53s of "Calculating task
+      # graph as no cached configuration is available" inside a ~2min step that
+      # ends up executing two tasks. Same action and same reasoning as
+      # android-app above, and the same ~/.gradle key, so the two jobs share one
+      # entry rather than each holding its own.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
       - name: Set up Android SDK
         # AGP needs the SDK to configure the :app project (compileSdk resolution),
-        # even though ktfmtCheck/detekt only read source files.
+        # even though ktfmtCheck/detekt only read source files. platform-tools
+        # alone, to skip the emulator the default `tools` package drags in (see
+        # android-app).
         uses: android-actions/setup-android@v3
+        with:
+          packages: platform-tools
 
       - name: Check Kotlin format (ktfmt) + lint (detekt)
         working-directory: android/Pipette

--- a/.github/workflows/ios-deadcode.yml
+++ b/.github/workflows/ios-deadcode.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Build llama.cpp (static lib + bindings)
         env:
           SCCACHE_GHA_ENABLED: "true"
+          # Must match build.yml's value or this workflow keys into a namespace
+          # of its own and shares nothing with ios-check, which builds the same
+          # sim slice. See the note on ios-check's build-llama step in build.yml.
+          SCCACHE_GHA_VERSION: "2"
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh sim
 
       - name: Generate MLX build info

--- a/.github/workflows/ios-deadcode.yml
+++ b/.github/workflows/ios-deadcode.yml
@@ -45,7 +45,6 @@ jobs:
           # of its own and shares nothing with ios-check, which builds the same
           # sim slice. See the note on ios-check's build-llama step in build.yml.
           SCCACHE_GHA_VERSION: "2"
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: ./ios/build-llama.sh sim
 
       - name: Generate MLX build info


### PR DESCRIPTION
## Why

The repo is past GitHub's 10 GB per-repo cache ceiling and has been LRU-evicting its own caches:

```
active_caches_size_in_bytes: 13,552,455,437   (limit 10 GB)
active_caches_count:         1,679
```

| Size | Entries | What |
|---|---|---|
| 4.41 GB | 14 | Swatinem rust-cache |
| 3.05 GB | **3** | setup-java gradle |
| 2.83 GB | 2 | iOS DerivedData |
| 1.73 GB | **3** | Android NDK |
| 0.60 GB | 1,656 | sccache |

The two three-entry rows are not three caches. They are the same key stored three times under different refs:

```
1041MB  ref=refs/heads/main               setup-java-Linux-x64-gradle-71680ca3...
1041MB  ref=refs/heads/release/2026.08.1  setup-java-Linux-x64-gradle-71680ca3...
1041MB  ref=refs/pull/4/merge             setup-java-Linux-x64-gradle-71680ca3...
 589MB  ref=refs/heads/main               android-ndk-27.2.12479018-Linux
 589MB  ref=refs/heads/release/2026.08.1  android-ndk-27.2.12479018-Linux
 589MB  ref=refs/pull/4/merge             android-ndk-27.2.12479018-Linux
```

That is ~3.2 GB of byte-identical duplication, roughly a third of the quota. Both are written by actions that save unconditionally on a miss, and GitHub scopes each save to the writing ref, so once the repo is evicting it feeds itself: a branch misses because main's copy was evicted, writes its own copy, evicts something else.

It already costs wall-clock. `android-app` spends 16-18s in "Post Set up JDK 17" and 15-16s in "Post Cache Android NDK" uploading duplicates. On runs 31492218667 and 31493653710 the NDK restore took 1s and the install step then took 32s, meaning the restore missed and the NDK was re-downloaded outright.

## What

**Gradle: `gradle/actions/setup-gradle` instead of setup-java's `cache: gradle`.** Its `cache-read-only` defaults to true off the default branch, so PR and release branches restore main's entry and write nothing. That removes the duplication and the post-step upload. It also prunes to what the build actually used instead of re-uploading a monolithic tarball.

Applied to three jobs, including two that had no Gradle cache at all:

- `android-app` (swap)
- `android-lint` (new). It resolved the whole plugin and dependency graph from cold Maven on every run. From run 31493653710: `Calculating task graph as no cached configuration is available` runs 12:57:27 to 12:58:31, so **64s of a `BUILD SUCCESSFUL in 1m 57s`** that ends up reporting `2 actionable tasks: 2 executed`. The Gradle distribution zip itself is re-downloaded each run too, since nothing was caching `~/.gradle/wrapper`.
- `android-release-distribution.yml` `distribute` (new). Same gap.

`cache-provider: basic` is pinned on all three. The action's default is `enhanced`, which its own `action.yml` describes as "the full-featured commercial caching service (gradle-actions-caching)". That would route this private repo's build cache through a third party. `basic` keeps it on the GitHub Actions cache, a drop-in swap for what setup-java was doing.

**NDK: restore always, save only on main.** The key names an exact NDK version, so a branch can never hold anything main does not already have.

**setup-android: `packages: platform-tools`.** The default `tools platform-tools` pulls the Android Emulator in as a dependency of the legacy `tools` package. The log is explicit: `[10% Installing Android Emulator]`. About 14s of a 23-27s step in every Android job, and nothing in CI boots an emulator.

## Verification

`validate-wrappers` is on by default in setup-gradle and fails the job on any wrapper jar that is not an official Gradle build, so this was checked before adopting. The committed jar hashes to `76805e32...93f3`, which does **not** match Gradle 9.4.1 (`55243ef5...145c`, the version in `distributionUrl`). Checked against all 370 published versions: it matches Gradle 9.0.0/9.1.0. A wrapper jar's checksum tracks whichever Gradle generated it, not the distribution it downloads, so comparing against `distributionUrl` alone would have been the wrong test. Net effect is a free supply-chain check we did not previously have.

Also run: YAML parse on both workflows, `actionlint` (only pre-existing shellcheck info on untouched scripts), `./ci/lint.sh`.

## Quota math

| | GB |
|---|---|
| Today | 13.55 |
| After the Gradle and NDK changes here | ~10.4 |
| After the rust-cache `save-if` in this PR | ~9.3 |

`rust-cache` has the same duplication: `rust-check-linux-v3` (782 MB) is stored under both `main` and `release/2026.08.1`, as are three more entries. `save-if: ${{ github.ref == 'refs/heads/main' }}` on the three call sites reclaims ~1.1 GB and is what brings the repo back under the ceiling.

The stale `setup-java-*-gradle-*` entries are orphaned by this PR. They age out after 7 days, or `gh cache delete` reclaims the ~3 GB immediately.

## sccache: 0% hits on android-app, and a diagnostic

`android-app` returns a **0% sccache hit rate** while `ios-check` returns **61.73%**, on the same backend and the same cache namespace (`ghac, name: cb1f7e36...`). The keys hash fine, one run scored 336/336. The difference is visibility.

GitHub scopes cache reads to your own ref plus the default branch, so main is the only ref everyone can read. Main holds no Android objects, because the run that would have seeded them failed every write:

| run | branch | requests | hits | misses | writes | write errors |
|---|---|---|---|---|---|---|
| 31451875696 | ci/github-hosted-runners | 336 | **336** | 0 | 0 | 0 |
| 31453116595 | release/2026.08.1 | 336 | 48 | 288 | 288 | 0 |
| 31493653710 | **main** | 336 | 0 | 336 | 0 | **336** |
| 31494024706 | release/2026.08.1 | 336 | 0 | 336 | 336 | 0 |
| 31523687135 | this PR | 336 | 0 | 336 | 326 | 10 |

sccache entries by ref today:

```
921  refs/pull/5/merge
651  refs/heads/release/2026.08.1
613  refs/heads/main      <- these are the iOS objects
```

Only main-ref writes are visible to anyone else, so main failing to write keeps every other ref cold, and the objects written on `release/*` and PR refs help nobody. In that state sccache costs more than it saves on this job: 336 requests, 336 misses, and 138s of cumulative write time producing objects nothing reads.

`--show-stats` reports a write failure only as a counter; the reason goes to sccache's server log, which is off by default. This PR turns it on at `warn` and uploads it as `sccache-error-log-android-app`.

First capture (run 31526311984) shows the error shape is an HTTP 409 from `CreateCacheEntry`:

```
{"code":"already_exists","msg":"cache entry with the same key, version, and scope already exists"}
... failed to start server: Address in use (os error 98)
```

**This does not yet explain the 336 failures.** Those 409s are on `.sccache_check`, the fixed-name probe sccache writes at startup to test whether the backend is writable. Every concurrent sccache job writes that same key into the same scope, so a 409 there is expected noise, not the cause. That run also had 336/336 read hits and wrote nothing, because it restored the 921 entries the previous run left under `refs/pull/5/merge` — a PR ref reading its own earlier writes, which is not evidence the problem is fixed. The decisive capture is the next run that actually writes, i.e. the first push to main after merge.

**The fix in this PR is `SCCACHE_GHA_VERSION: "2"`**, set at all five sccache sites. That selects the namespace every object is keyed into, so bumping it abandons the poisoned one. Verified in run 31534737956: the namespace moved from `cb1f7e36...` to `58ebc4fa...` and every lookup now reports `the key doesn't exist` rather than colliding. It costs one cold build per job while v2 reseeds, including the iOS cache that was working.

`ios-deadcode.yml` carries the same version string, or it keys into a namespace of its own despite building the identical sim slice.

Both are set per-step beside `SCCACHE_GHA_ENABLED` rather than workflow-wide, because sccache treats `SCCACHE_GHA_VERSION` as implying `SCCACHE_GHA_ENABLED`, and a top-level value would switch the backend on inside the in-Xcode build that `PIPETTE_SKIP_BUILD_LLAMA` exists to keep out of it.

**What this PR deliberately does not do is restrict sccache writes to main.** It was tried in 8c64bf24 and reverted in 3a4b1711 on measurement. Every other cache here is main-writes-only, but sccache is the opposite shape: many small objects rather than one blob, so a PR's copy holds only what that PR compiled instead of duplicating main's, and it is what lets a second run on the same PR reuse the first. Restricting it took android-app's native build from 2m37s warm to 8m10s, ios-check to 16m36s and ios-archive to 16m26s, on every PR run rather than once, to reclaim 239 MB (2.4% of the ceiling) in entries GitHub deletes when the PR closes. It also pinned `cache_write_errors` at one per object on every non-main run, which is the counter that found the poisoning to begin with.

Longer term an S3/R2 backend removes ref scoping entirely: one namespace, every branch reading and writing the same objects. Worth noting the reason would be *effectiveness*, not quota. sccache is 0.61 GB of 9.72 GB here, 99.5% of the entry count but 6% of the bytes, and GitHub limits bytes.

## Not in this PR

- **Moving sccache to a bucket backend.** See the section above for why that is the structural fix. It needs a bucket and credentials, so only the diagnostic is here.
- **`RUSTC_WRAPPER: sccache` on `build-artifact`.** That job compiles no C/C++ (only `pipette-memprobe-metal` uses `cc::Build`, and it is macOS-only), so sccache wraps rustc alone there, which is the configuration the comment at `build.yml:164` says was measured at ~38% on Linux and ~2% on Windows and removed from `rust-check`. Separate question, separate change.
- **Gradle configuration cache persistence.** Both Android jobs log `Configuration cache entry stored` and then report none available on the next run. `setup-gradle`'s `cache-encryption-key` is what enables it, and it needs a new `GRADLE_ENCRYPTION_KEY` repo secret.

## Ruled out

`ios-archive`'s 297s archive step is 343 CompileC + 70 SwiftCompile, essentially all SwiftPM (Cmlx 180, phlibwebp 87, PHPLCrashReporter 60, SwiftSyntax across 6 versions). Xcode 26's compilation caching would be the lever but explicitly does not cover SPM dependencies yet, so the existing comment in the workflow is correct and there is nothing to win there.
