### PR TITLE
feat: observe host and swap peak memory on every benchmark

### DIFF
--- a/crates/pipette-cli/src/results/record.rs
+++ b/crates/pipette-cli/src/results/record.rs
@@ -154,6 +154,9 @@ pub fn build_submission_payload_from_run(
         device_power_state: power.power_state,
         device_power_save_mode: power.power_save_mode,
         thermal: ThermalTelemetry::from_series(&outcome.thermal.before, &outcome.thermal.after),
+        // Passed straight through: the engine observed it, and unlike thermal
+        // there is no per-rep series for the caller to fold.
+        memory: outcome.memory,
         model_descriptor,
         runtime_descriptor,
         model_flags: req

--- a/crates/pipette-llamacpp/src/bench.rs
+++ b/crates/pipette-llamacpp/src/bench.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use pipette_ops::measurement;
 use pipette_ops::readiness::{ReadinessGate, RepObserver};
+use pipette_plan_types::result::MemoryObservation;
 use pipette_plan_types::{LlamacppFlashAttention, RuntimeFlagRef, RuntimeFlags};
 use pipette_subprocess::{argv, echo_info};
 
@@ -112,6 +113,9 @@ struct LlamaBenchExecution {
     stdout: String,
     stderr: String,
     rows: Vec<LlamaBenchRow>,
+    /// What memory this one invocation held. Folded across reps by
+    /// [`execute_reps`] into the run's observation.
+    memory: MemoryObservation,
 }
 
 fn execute(mut command: Command) -> anyhow::Result<LlamaBenchExecution> {
@@ -151,9 +155,11 @@ fn execute(mut command: Command) -> anyhow::Result<LlamaBenchExecution> {
     // timeout-killer firing) leaves the registry empty for this pid.
     let _cleanup_guard = pipette_subprocess::cleanup::Guard::for_process_group(pid);
     let killer = spawn_timeout_killer(LLAMA_BENCH_TIMING_TIMEOUT, move || kill_pid(pid));
+    let memory_observer = crate::run_memory::RunMemoryObserver::attach(pid);
     let output = child
         .wait_with_output()
         .with_context(|| format!("failed to wait for {program}"))?;
+    let memory = memory_observer.finish();
     let killer_fired = killer.fired();
     drop(killer);
 
@@ -179,6 +185,7 @@ fn execute(mut command: Command) -> anyhow::Result<LlamaBenchExecution> {
         stdout,
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         rows,
+        memory,
     })
 }
 
@@ -204,6 +211,8 @@ pub struct BenchRepSummary {
     pub stderr: String,
     pub mean_ms: f64,
     pub stddev_ms: f64,
+    /// The worst memory any rep held. Not a metric — see [`MemoryObservation`].
+    pub memory: MemoryObservation,
 }
 
 pub fn execute_reps(
@@ -233,6 +242,13 @@ pub fn execute_reps(
         .first()
         .map(|execution| execution.preview.clone())
         .unwrap_or_default();
+    // Folded before `measured` is consumed below, and across every rep rather
+    // than the last one: the run's observation is the worst any rep reached.
+    let memory = measured
+        .iter()
+        .fold(MemoryObservation::default(), |worst, rep| {
+            worst.merge_max(rep.value.memory)
+        });
     let (stdout, stderr) = measured
         .into_iter()
         .next_back()
@@ -245,6 +261,7 @@ pub fn execute_reps(
         stderr,
         mean_ms: stats.mean_ms,
         stddev_ms: stats.stddev_ms,
+        memory,
     })
 }
 

--- a/crates/pipette-llamacpp/src/execute/decode_throughput.rs
+++ b/crates/pipette-llamacpp/src/execute/decode_throughput.rs
@@ -60,6 +60,7 @@ pub fn run(
         executable: Some(llama_bench.display().to_string()),
         command: summary.preview,
         runtime_flags: Some(flags),
+        memory: summary.memory,
         ..RunResponse::new(
             BenchmarkResultData::DecodeThroughput {
                 decode_time_ms: summary.mean_ms,

--- a/crates/pipette-llamacpp/src/execute/end_to_end_latency.rs
+++ b/crates/pipette-llamacpp/src/execute/end_to_end_latency.rs
@@ -48,6 +48,7 @@ pub fn run(
     let decode_tokens = benchmark.parameter_decode_tokens;
     let http_timeout = http_timeout_from_req(req);
     let mut server = server::start(&llama_server, &model_path, None, &extra_flags)?;
+    server.observe_memory();
 
     let result = (|| -> anyhow::Result<RunResponse> {
         if let Err(e) = server::wait_until_ready(&server.base_url, &mut server.child, http_timeout)
@@ -121,6 +122,7 @@ pub fn run(
             executable: Some(llama_server.display().to_string()),
             command: server.command_preview.clone(),
             runtime_flags: Some(flags.clone()),
+            memory: server.memory_observation(),
             ..RunResponse::new(
                 BenchmarkResultData::EndToEndLatency {
                     total_time_ms: stats.mean_ms,

--- a/crates/pipette-llamacpp/src/execute/eval.rs
+++ b/crates/pipette-llamacpp/src/execute/eval.rs
@@ -226,11 +226,9 @@ pub fn run_eval(
         // only in `--port`.
         command: server.command_preview.clone(),
         runtime_flags: Some(flags.clone()),
-        // No memory observation: eval deliberately reports none. It can restart
-        // `llama-server` mid-run after a crash, and the surviving handle has only
-        // watched the replacement, so any single figure would describe part of the
-        // run while looking like it described all of it. Leaving the field empty
-        // says "not observed", which is true. `RunResponse::new` defaults it.
+        // No memory observation, deliberately: eval can restart `llama-server`
+        // mid-run, so no single figure describes the whole run. See
+        // `RunningLlamaServer::observe_memory`; `RunResponse::new` defaults it.
         ..RunResponse::new(
             BenchmarkResultData::Eval { completions },
             String::new(),

--- a/crates/pipette-llamacpp/src/execute/eval.rs
+++ b/crates/pipette-llamacpp/src/execute/eval.rs
@@ -226,6 +226,11 @@ pub fn run_eval(
         // only in `--port`.
         command: server.command_preview.clone(),
         runtime_flags: Some(flags.clone()),
+        // No memory observation: eval deliberately reports none. It can restart
+        // `llama-server` mid-run after a crash, and the surviving handle has only
+        // watched the replacement, so any single figure would describe part of the
+        // run while looking like it described all of it. Leaving the field empty
+        // says "not observed", which is true. `RunResponse::new` defaults it.
         ..RunResponse::new(
             BenchmarkResultData::Eval { completions },
             String::new(),

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
@@ -137,9 +137,12 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
-        // Same sampler the metric came from, so this arm's observation and its
-        // metric agree. Reported anyway: a consumer reading observations across
-        // benchmarks should not have to special-case the memory one.
+        // Same sampler as the metric, read differently on purpose: the metric
+        // above is the swap-aware peak (`peak_ram_kib`), this is the resident
+        // watermark with the swap term beside it. On a row that swapped the two
+        // will differ, and that difference is the metric's swap uplift made
+        // legible. Reported at all because a consumer reading observations
+        // across benchmarks should not have to special-case the memory one.
         memory: crate::run_memory::observation_from(&footprint),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
@@ -21,7 +21,7 @@ use std::{
 
 use anyhow::Context;
 
-use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
+use pipette_plan_types::result::BenchmarkResultData;
 use pipette_plan_types::RuntimeFlags;
 use pipette_subprocess::{argv, echo_info};
 
@@ -140,10 +140,7 @@ pub(super) fn run(
         // Same sampler the metric came from, so this arm's observation and its
         // metric agree. Reported anyway: a consumer reading observations across
         // benchmarks should not have to special-case the memory one.
-        memory: MemoryObservation {
-            max_host_bytes: Some(max_host_bytes),
-            max_swap_bytes: Some(footprint.max_swap_bytes()),
-        },
+        memory: crate::run_memory::observation_from(&footprint),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs
@@ -21,16 +21,16 @@ use std::{
 
 use anyhow::Context;
 
-use pipette_plan_types::result::BenchmarkResultData;
+use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
 use pipette_plan_types::RuntimeFlags;
 use pipette_subprocess::{argv, echo_info};
 
 use super::super::RunResponse;
-use super::proc_footprint::{peak_ram_bytes, spawn_footprint_poller};
 use super::Params;
 use crate::common::{
     apply_dylib_search_env, deadline_error_message, spawn_timeout_killer, MAX_MEMORY_USAGE_TIMEOUT,
 };
+use crate::run_memory::proc_footprint::{peak_ram_bytes, spawn_footprint_poller};
 
 pub(super) fn run(
     llama_bench: &Path,
@@ -137,6 +137,13 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
+        // Same sampler the metric came from, so this arm's observation and its
+        // metric agree. Reported anyway: a consumer reading observations across
+        // benchmarks should not have to special-case the memory one.
+        memory: MemoryObservation {
+            max_host_bytes: Some(max_host_bytes),
+            max_swap_bytes: Some(footprint.max_swap_bytes()),
+        },
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
@@ -27,7 +27,7 @@ use std::{
 // in scope. `bail!` and `Result` are written `anyhow::`-qualified at use sites.
 use anyhow::Context;
 
-use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
+use pipette_plan_types::result::BenchmarkResultData;
 use pipette_plan_types::RuntimeFlags;
 use pipette_subprocess::{argv, echo_info};
 
@@ -134,11 +134,9 @@ pub(super) fn run(
         // that is the whole point of the split. A Linux row whose observed peak
         // exceeds its `max_host_bytes` is showing exactly the under-reporting the
         // metric still carries, and names the hosts where adopting the
-        // swap-aware peak would change anything.
-        memory: MemoryObservation {
-            max_host_bytes: Some(footprint.peak_ram_kib().saturating_mul(1024)),
-            max_swap_bytes: Some(footprint.max_swap_bytes()),
-        },
+        // swap-aware peak would change anything. Through the same rule the
+        // timing benchmarks use, so one sampler cannot mean two things.
+        memory: crate::run_memory::observation_from(&footprint),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
@@ -130,12 +130,12 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
-        // The observation is swap-aware even though the metric above is not:
-        // that is the whole point of the split. A Linux row whose observed peak
-        // exceeds its `max_host_bytes` is showing exactly the under-reporting the
-        // metric still carries, and names the hosts where adopting the
-        // swap-aware peak would change anything. Through the same rule the
-        // timing benchmarks use, so one sampler cannot mean two things.
+        // Both resident-only, so the observation restates this arm's metric and
+        // adds the swap term beside it. That term is the point here: it names
+        // the hosts where this metric is being suppressed by reclaim, which is
+        // what adopting the swap-aware peak on Linux would have to be argued
+        // from. Through the same rule the timing benchmarks use, so one sampler
+        // cannot mean two things.
         memory: crate::run_memory::observation_from(&footprint),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/linux.rs
@@ -27,7 +27,7 @@ use std::{
 // in scope. `bail!` and `Result` are written `anyhow::`-qualified at use sites.
 use anyhow::Context;
 
-use pipette_plan_types::result::BenchmarkResultData;
+use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
 use pipette_plan_types::RuntimeFlags;
 use pipette_subprocess::{argv, echo_info};
 
@@ -86,7 +86,7 @@ pub(super) fn run(
         libc::kill(-pgid, libc::SIGKILL);
     });
 
-    let poller = super::proc_footprint::spawn_footprint_poller(pid);
+    let poller = crate::run_memory::proc_footprint::spawn_footprint_poller(pid);
 
     let output = child
         .wait_with_output()
@@ -95,7 +95,8 @@ pub(super) fn run(
     // footprint the Android arm reports; adopting it here needs the same
     // model-file floor, so it is left to a follow-up rather than changing what
     // Linux rows mean as a side effect.
-    let max_kib = poller.stop_and_join().peak_rss_kib;
+    let footprint = poller.stop_and_join();
+    let max_kib = footprint.peak_rss_kib;
     let killer_fired = killer.fired();
     drop(killer);
 
@@ -129,6 +130,15 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
+        // The observation is swap-aware even though the metric above is not:
+        // that is the whole point of the split. A Linux row whose observed peak
+        // exceeds its `max_host_bytes` is showing exactly the under-reporting the
+        // metric still carries, and names the hosts where adopting the
+        // swap-aware peak would change anything.
+        memory: MemoryObservation {
+            max_host_bytes: Some(footprint.peak_ram_kib().saturating_mul(1024)),
+            max_swap_bytes: Some(footprint.max_swap_bytes()),
+        },
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
@@ -136,17 +136,10 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
-        // `phys_footprint` bills compressed pages to the process, so the peak
-        // already counts them and there is no separate swap term to observe.
-        //
-        // A zero means no `proc_pid_rusage` call landed — the poller tolerates a
-        // failing read rather than erroring — so it is withheld, matching
-        // `RunMemoryObserver::finish`. Absence means "not observed" here, and a
-        // zero would read as a measurement instead.
-        memory: MemoryObservation {
-            max_host_bytes: (phys_peak > 0).then_some(phys_peak),
-            max_swap_bytes: None,
-        },
+        // No swap term: `phys_footprint` bills compressed pages to the process,
+        // so the peak already counts them. `host_only` withholds a zero, which
+        // here means no `proc_pid_rusage` read landed.
+        memory: MemoryObservation::host_only(phys_peak),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
@@ -25,7 +25,7 @@ use std::{
 use anyhow::Context;
 
 use pipette_memprobe_metal::{host, metal};
-use pipette_plan_types::result::BenchmarkResultData;
+use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
 use pipette_plan_types::RuntimeFlags;
 use pipette_subprocess::{argv, echo_info};
 
@@ -136,6 +136,12 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
+        // `phys_footprint` bills compressed pages to the process, so the peak
+        // already counts them and there is no separate swap term to observe.
+        memory: MemoryObservation {
+            max_host_bytes: Some(phys_peak),
+            max_swap_bytes: None,
+        },
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
@@ -138,8 +138,13 @@ pub(super) fn run(
         runtime_flags: Some(flags.clone()),
         // `phys_footprint` bills compressed pages to the process, so the peak
         // already counts them and there is no separate swap term to observe.
+        //
+        // A zero means no `proc_pid_rusage` call landed — the poller tolerates a
+        // failing read rather than erroring — so it is withheld, matching
+        // `RunMemoryObserver::finish`. Absence means "not observed" here, and a
+        // zero would read as a measurement instead.
         memory: MemoryObservation {
-            max_host_bytes: Some(phys_peak),
+            max_host_bytes: (phys_peak > 0).then_some(phys_peak),
             max_swap_bytes: None,
         },
         ..RunResponse::new(

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/macos.rs
@@ -84,9 +84,13 @@ pub(super) fn run(
         .context("failed to wait for llama-bench")?;
     let killer_fired = killer.fired();
     drop(killer);
+    // The metric takes the peak alone: it polls at 20 ms across a whole load, so
+    // the seed-only case the `samples` count exists to catch cannot arise here.
+    // The observation channel applies that rule (`observation_from_phys`).
     let phys_peak = phys_poller
         .stop_and_join()
-        .context("phys_footprint poller failed; max_host_bytes is unreliable")?;
+        .context("phys_footprint poller failed; max_host_bytes is unreliable")?
+        .peak_bytes;
 
     if killer_fired {
         anyhow::bail!(

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/mod.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/mod.rs
@@ -9,7 +9,7 @@
 //!   gives in-process `[MTLDevice currentAllocatedSize]`. Host
 //!   counter is `phys_footprint`.
 //! - [`android`] — runs `llama-bench` under a `/proc` footprint sampler
-//!   ([`proc_footprint`]) and reports `max(VmHWM, max(VmRSS + VmSwap))`,
+//!   ([`crate::run_memory::proc_footprint`]) and reports `max(VmHWM, max(VmRSS + VmSwap))`,
 //!   because zram can compress the model out of the resident set mid-run
 //!   and a peak-RSS figure alone then under-reports what the run required.
 //!   No GPU probe (CPU-only Android build).
@@ -70,8 +70,6 @@ mod linux;
 mod macos;
 #[cfg(target_os = "windows")]
 mod pdh_poller;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-mod proc_footprint;
 #[cfg(target_os = "windows")]
 mod windows;
 

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
@@ -77,7 +77,7 @@ use windows_sys::Win32::{
     },
 };
 
-use pipette_plan_types::result::BenchmarkResultData;
+use pipette_plan_types::result::{BenchmarkResultData, MemoryObservation};
 use pipette_plan_types::{LlamaCppFlavor, RuntimeFlags};
 use pipette_subprocess::{argv, echo_info};
 
@@ -246,6 +246,12 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
+        // `PeakWorkingSetSize` is resident-only and PSAPI exposes no paged-out
+        // watermark, so there is no swap term to observe here yet.
+        memory: MemoryObservation {
+            max_host_bytes: Some(max_host_bytes),
+            max_swap_bytes: None,
+        },
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
@@ -246,14 +246,9 @@ pub(super) fn run(
         executable: Some(llama_bench.display().to_string()),
         command: preview,
         runtime_flags: Some(flags.clone()),
-        // `PeakWorkingSetSize` is resident-only and PSAPI exposes no paged-out
-        // watermark, so there is no swap term to observe here yet. A zero
-        // watermark is withheld for the same reason as the macOS arm: absence
-        // means "not observed", and a zero would read as a measurement.
-        memory: MemoryObservation {
-            max_host_bytes: (max_host_bytes > 0).then_some(max_host_bytes),
-            max_swap_bytes: None,
-        },
+        // No swap term: `PeakWorkingSetSize` is resident-only and PSAPI exposes
+        // no paged-out watermark yet.
+        memory: MemoryObservation::host_only(max_host_bytes),
         ..RunResponse::new(
             BenchmarkResultData::MaxMemoryUsage {
                 max_host_bytes,

--- a/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
+++ b/crates/pipette-llamacpp/src/execute/max_memory_usage/windows.rs
@@ -247,9 +247,11 @@ pub(super) fn run(
         command: preview,
         runtime_flags: Some(flags.clone()),
         // `PeakWorkingSetSize` is resident-only and PSAPI exposes no paged-out
-        // watermark, so there is no swap term to observe here yet.
+        // watermark, so there is no swap term to observe here yet. A zero
+        // watermark is withheld for the same reason as the macOS arm: absence
+        // means "not observed", and a zero would read as a measurement.
         memory: MemoryObservation {
-            max_host_bytes: Some(max_host_bytes),
+            max_host_bytes: (max_host_bytes > 0).then_some(max_host_bytes),
             max_swap_bytes: None,
         },
         ..RunResponse::new(

--- a/crates/pipette-llamacpp/src/execute/prefill_throughput.rs
+++ b/crates/pipette-llamacpp/src/execute/prefill_throughput.rs
@@ -57,6 +57,7 @@ pub fn run(
         executable: Some(llama_bench.display().to_string()),
         command: summary.preview,
         runtime_flags: Some(flags),
+        memory: summary.memory,
         ..RunResponse::new(
             BenchmarkResultData::PrefillThroughput {
                 prefill_time_ms: summary.mean_ms,

--- a/crates/pipette-llamacpp/src/execute/vl_throughput.rs
+++ b/crates/pipette-llamacpp/src/execute/vl_throughput.rs
@@ -63,6 +63,7 @@ pub fn run(
     let http_timeout = http_timeout_from_req(req);
 
     let mut server = server::start(&llama_server, &model_path, Some(&mmproj_path), &extra_flags)?;
+    server.observe_memory();
 
     let result = (|| -> anyhow::Result<RunResponse> {
         if let Err(e) = server::wait_until_ready(&server.base_url, &mut server.child, http_timeout)
@@ -132,6 +133,7 @@ pub fn run(
             executable: Some(llama_server.display().to_string()),
             command: server.command_preview.clone(),
             runtime_flags: Some(flags.clone()),
+            memory: server.memory_observation(),
             ..RunResponse::new(
                 BenchmarkResultData::VlThroughput {
                     prompt_tokens,

--- a/crates/pipette-llamacpp/src/lib.rs
+++ b/crates/pipette-llamacpp/src/lib.rs
@@ -4,6 +4,7 @@ pub mod execute;
 pub mod flags;
 pub mod github;
 pub mod models;
+mod run_memory;
 mod runtime_flags;
 pub mod runtimes;
 mod server;

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -8,11 +8,13 @@
 //! of the model is a different fact from one measured resident, and without this
 //! nothing in the row distinguishes them.
 //!
-//! Because it never feeds a scored figure, this is free to report the
-//! swap-aware peak wherever the sampler supplies one. The `max_memory_usage`
-//! metric keeps its own per-arm definition (Linux still reports resident-only
-//! there); the two are allowed to disagree, and that disagreement is exactly
-//! what the swap term explains.
+//! The host term is the **resident** watermark, so the field means one thing
+//! wherever it appears, and the swap term rides beside it rather than inside it.
+//! A run that swapped is recognised by a non-zero swap term, not by an inflated
+//! peak. That keeps the two terms independently checkable and leaves the
+//! swap-aware *sum* where it is already scored: the `max_memory_usage` metric,
+//! whose Android arm reports it. An Android row where the metric exceeds this
+//! observation is showing exactly that difference.
 //!
 //! Attaching is per OS and by design incomplete: an arm with no sampler
 //! observes nothing and contributes no keys, which is why every field is
@@ -169,8 +171,12 @@ pub(crate) fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryO
     if footprint.samples < 2 {
         return MemoryObservation::default();
     }
+    // `peak_rss_kib` (VmHWM), deliberately not `peak_ram_kib()`: the host term is
+    // the resident watermark, so the field means the same thing on every arm that
+    // can report it. The swap-aware sum stays out of it and rides beside it as
+    // the swap term, which is what says the resident figure was suppressed.
     MemoryObservation::with_swap(
-        footprint.peak_ram_kib().saturating_mul(1024),
+        footprint.peak_rss_kib.saturating_mul(1024),
         footprint.max_swap_bytes(),
     )
 }
@@ -206,6 +212,32 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(observation_from(&footprint), expected);
+    }
+
+    /// The host term is the resident watermark, never the swap-aware sum. Figures
+    /// are a real S26 Ultra reading: `VmHWM` 5004 MiB while zram held 4105 MiB of
+    /// the run, summing to the 6138 MiB the `max_memory_usage` metric reports on
+    /// Android. Only the resident term may appear here, or the field means two
+    /// things depending on the arm that filled it.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn the_host_term_stays_resident_when_the_run_swapped() {
+        let footprint = proc_footprint::Footprint {
+            peak_rss_kib: 5_124_688,
+            peak_committed_kib: 6_285_312,
+            max_swap_kib: 4_203_520,
+            samples: 64,
+            ..Default::default()
+        };
+        assert_eq!(
+            observation_from(&footprint),
+            MemoryObservation::with_swap(5_124_688 * 1024, 4_203_520 * 1024)
+        );
+        assert_eq!(
+            footprint.peak_ram_kib(),
+            6_285_312,
+            "the swap-aware sum still exists for the metric that scores it"
+        );
     }
 
     /// The macOS arm needs the same rule as the `/proc` one: the read taken as

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -142,11 +142,12 @@ impl RunMemoryObserver {
 
 /// What a `phys_footprint` reading is worth reporting as, or nothing.
 ///
-/// The macOS counterpart of [`observation_from`], applying the same rule: the
-/// read taken as the poller starts happens before the child has loaded
-/// anything, so a footprint built only from it describes startup rather than the
-/// run. `phys_footprint` being a watermark does not help here — the watermark is
-/// simply small that early.
+/// The macOS counterpart of [`observation_from`], applying the same rule for the
+/// same reason (`PhysFootprint::samples`). Weaker here than on `/proc`: that
+/// sampler seeds synchronously, so one sample provably means startup, while this
+/// poller's first read lands whenever its thread is scheduled. The guard only
+/// ever withholds, so the difference costs a short run its observation rather
+/// than putting a wrong figure on a row.
 #[cfg(target_os = "macos")]
 fn observation_from_phys(
     footprint: pipette_memprobe_metal::host::PhysFootprint,
@@ -165,16 +166,17 @@ fn observation_from_phys(
 /// from a live process.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryObservation {
-    // A seed-only footprint describes process startup in a few plausible-looking
-    // MB that a consumer cannot tell apart from a real measurement, so it is
-    // withheld on top of the zero rule the constructor applies.
+    // Withheld on top of the zero rule the constructor applies: see
+    // `Footprint::samples`.
     if footprint.samples < 2 {
         return MemoryObservation::default();
     }
     // `peak_rss_kib` (VmHWM), deliberately not `peak_ram_kib()`: the host term is
     // the resident watermark, so the field means the same thing on every arm that
     // can report it. The swap-aware sum stays out of it and rides beside it as
-    // the swap term, which is what says the resident figure was suppressed.
+    // the swap term, which is what says the resident figure was suppressed. An
+    // unreadable VmHWM therefore withholds the swap reading too, rather than
+    // reporting a term whose peak is missing.
     MemoryObservation::with_swap(
         footprint.peak_rss_kib.saturating_mul(1024),
         footprint.max_swap_bytes(),
@@ -185,64 +187,46 @@ pub(crate) fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryO
 mod tests {
     use super::*;
 
-    /// The seed is taken before the child has loaded anything, so a footprint
-    /// built only from it describes startup, not the run. Reporting it would put
-    /// a few MB on a row as though measured; these cases pin that it is withheld.
+    /// What reaches a row from a `/proc` footprint: the resident peak, only once
+    /// a read has landed after the seed, and never half an observation.
     ///
-    /// Asserts the whole observation, not just the peak: a withheld peak has to
-    /// take the swap term with it, or the row claims swap was sampled while
-    /// refusing to say what it held.
+    /// Asserts the whole observation rather than the peak alone, since a
+    /// withheld peak has to take the swap term with it.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[rstest::rstest]
-    #[case::seed_only_is_withheld(3_000, 1, MemoryObservation::default())]
-    #[case::nothing_read_is_withheld(0, 0, MemoryObservation::default())]
+    #[case::seed_only_is_withheld(3_000, 0, 0, 1, MemoryObservation::default())]
+    #[case::nothing_read_is_withheld(0, 0, 0, 0, MemoryObservation::default())]
     #[case::a_post_seed_read_is_reported(
-        6_440_000,
-        2,
+        6_440_000, 0, 0, 2,
         MemoryObservation::with_swap(6_440_000 * 1024, 0)
     )]
-    fn an_observation_needs_a_read_after_the_seed(
+    // A measured S26 Ultra footprint: `VmHWM` 5004 MiB while zram held 4105 MiB,
+    // the two summing to the 6138 MiB the Android metric scores. Only the
+    // resident term may appear here, or the field means one thing on an arm that
+    // swapped and another on one that did not.
+    #[case::swapping_reports_the_resident_term(
+        5_124_688, 6_285_312, 4_203_520, 64,
+        MemoryObservation::with_swap(5_124_688 * 1024, 4_203_520 * 1024)
+    )]
+    fn an_observation_reports_the_resident_peak_after_the_seed(
         #[case] peak_rss_kib: u64,
+        #[case] peak_committed_kib: u64,
+        #[case] max_swap_kib: u64,
         #[case] samples: u32,
         #[case] expected: MemoryObservation,
     ) {
         let footprint = proc_footprint::Footprint {
             peak_rss_kib,
+            peak_committed_kib,
+            max_swap_kib,
             samples,
             ..Default::default()
         };
         assert_eq!(observation_from(&footprint), expected);
     }
 
-    /// The host term is the resident watermark, never the swap-aware sum. Figures
-    /// are a real S26 Ultra reading: `VmHWM` 5004 MiB while zram held 4105 MiB of
-    /// the run, summing to the 6138 MiB the `max_memory_usage` metric reports on
-    /// Android. Only the resident term may appear here, or the field means two
-    /// things depending on the arm that filled it.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[test]
-    fn the_host_term_stays_resident_when_the_run_swapped() {
-        let footprint = proc_footprint::Footprint {
-            peak_rss_kib: 5_124_688,
-            peak_committed_kib: 6_285_312,
-            max_swap_kib: 4_203_520,
-            samples: 64,
-            ..Default::default()
-        };
-        assert_eq!(
-            observation_from(&footprint),
-            MemoryObservation::with_swap(5_124_688 * 1024, 4_203_520 * 1024)
-        );
-        assert_eq!(
-            footprint.peak_ram_kib(),
-            6_285_312,
-            "the swap-aware sum still exists for the metric that scores it"
-        );
-    }
-
-    /// The macOS arm needs the same rule as the `/proc` one: the read taken as
-    /// the poller starts describes startup, so a footprint built only from it is
-    /// withheld rather than reported as a measurement.
+    /// The macOS arm needs the same rule as the `/proc` one, and withholds a
+    /// zero on top of it.
     #[cfg(target_os = "macos")]
     #[rstest::rstest]
     #[case::seed_only_is_withheld(3_000_000, 1, MemoryObservation::default())]

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -34,6 +34,36 @@ pub(crate) mod proc_footprint;
 
 use pipette_plan_types::result::MemoryObservation;
 
+/// A `sleep` child, killed and reaped on drop.
+///
+/// Several tests here and in [`proc_footprint`] need a live process to point a
+/// sampler at. Cleanup belongs on `Drop` rather than at the end of each test: an
+/// assertion that fires early would otherwise leave the child running for the
+/// rest of its duration.
+#[cfg(all(test, unix))]
+pub(crate) struct SleepChild(std::process::Child);
+
+#[cfg(all(test, unix))]
+impl SleepChild {
+    pub(crate) fn spawn(seconds: &str) -> anyhow::Result<Self> {
+        Ok(Self(
+            std::process::Command::new("sleep").arg(seconds).spawn()?,
+        ))
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.0.id()
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for SleepChild {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
 /// Observes a spawned child until [`Self::finish`]. Attach right after spawn;
 /// finish after the child is waited for.
 ///
@@ -66,6 +96,12 @@ impl RunMemoryObserver {
         // something rarer.
         #[cfg(any(target_os = "linux", target_os = "android"))]
         let inner = Inner::Proc(proc_footprint::spawn_observation_poller(pid));
+        // Unlike the `/proc` arm this one has no identity guard: a caller that
+        // reaps before finishing leaves a window of at most one interval in which
+        // a read could land on a recycled pid and be folded into the peak. Known
+        // and accepted — `proc_pid_rusage` carries no start time to compare, the
+        // metric path has always had the same window, and macOS would have to
+        // recycle a pid within ~100 ms of the reap to hit it.
         #[cfg(target_os = "macos")]
         let inner = Inner::PhysFootprint(
             pipette_memprobe_metal::host::spawn_phys_footprint_poller_for_observation(pid as i32),
@@ -89,16 +125,13 @@ impl RunMemoryObserver {
         match self.inner {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             Inner::Proc(poller) => observation_from(&poller.stop_and_join()),
+            // `host_only` because `phys_footprint` bills compressed pages to the
+            // process: the peak already counts them and no separate term exists.
             #[cfg(target_os = "macos")]
-            Inner::PhysFootprint(poller) => match poller.stop_and_join() {
-                Ok(0) | Err(_) => MemoryObservation::default(),
-                Ok(bytes) => MemoryObservation {
-                    max_host_bytes: Some(bytes),
-                    // `phys_footprint` bills compressed pages to the process, so
-                    // the peak already counts them and no separate term exists.
-                    max_swap_bytes: None,
-                },
-            },
+            Inner::PhysFootprint(poller) => poller
+                .stop_and_join()
+                .map(MemoryObservation::host_only)
+                .unwrap_or_default(),
             #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
             Inner::Unobserved => MemoryObservation::default(),
         }
@@ -107,21 +140,22 @@ impl RunMemoryObserver {
 
 /// What a `/proc` footprint is worth reporting as, or nothing.
 ///
-/// Separate from [`RunMemoryObserver::finish`] so the rule is decidable from a
-/// hand-built footprint instead of only from a live process.
+/// The single rule for this sampler, used by [`RunMemoryObserver::finish`] and
+/// by the `max_memory_usage` arms that hold a footprint of their own. Separate
+/// from `finish` so it is decidable from a hand-built footprint instead of only
+/// from a live process.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryObservation {
-    // A zero peak means nobody looked. A seed-only footprint is worse: it
-    // describes process startup in a few plausible-looking MB that a consumer
-    // cannot tell apart from a real measurement. Absence is filterable, a wrong
-    // number is not.
-    if footprint.peak_ram_kib() == 0 || footprint.samples < 2 {
+pub(crate) fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryObservation {
+    // A seed-only footprint describes process startup in a few plausible-looking
+    // MB that a consumer cannot tell apart from a real measurement, so it is
+    // withheld on top of the zero rule the constructor applies.
+    if footprint.samples < 2 {
         return MemoryObservation::default();
     }
-    MemoryObservation {
-        max_host_bytes: Some(footprint.peak_ram_kib().saturating_mul(1024)),
-        max_swap_bytes: Some(footprint.max_swap_bytes()),
-    }
+    MemoryObservation::with_swap(
+        footprint.peak_ram_kib().saturating_mul(1024),
+        footprint.max_swap_bytes(),
+    )
 }
 
 #[cfg(test)]
@@ -131,25 +165,30 @@ mod tests {
     /// The seed is taken before the child has loaded anything, so a footprint
     /// built only from it describes startup, not the run. Reporting it would put
     /// a few MB on a row as though measured; these cases pin that it is withheld.
+    ///
+    /// Asserts the whole observation, not just the peak: a withheld peak has to
+    /// take the swap term with it, or the row claims swap was sampled while
+    /// refusing to say what it held.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[rstest::rstest]
-    #[case::seed_only_is_withheld(3_000, 1, None)]
-    #[case::nothing_read_is_withheld(0, 0, None)]
-    #[case::a_post_seed_read_is_reported(6_440_000, 2, Some(6_440_000 * 1024))]
+    #[case::seed_only_is_withheld(3_000, 1, MemoryObservation::default())]
+    #[case::nothing_read_is_withheld(0, 0, MemoryObservation::default())]
+    #[case::a_post_seed_read_is_reported(
+        6_440_000,
+        2,
+        MemoryObservation::with_swap(6_440_000 * 1024, 0)
+    )]
     fn an_observation_needs_a_read_after_the_seed(
         #[case] peak_rss_kib: u64,
         #[case] samples: u32,
-        #[case] expected_host_bytes: Option<u64>,
+        #[case] expected: MemoryObservation,
     ) {
         let footprint = proc_footprint::Footprint {
             peak_rss_kib,
             samples,
             ..Default::default()
         };
-        assert_eq!(
-            observation_from(&footprint).max_host_bytes,
-            expected_host_bytes
-        );
+        assert_eq!(observation_from(&footprint), expected);
     }
 
     /// The observer must work without the caller knowing which platform it is
@@ -161,12 +200,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn an_observation_is_either_populated_or_absent_but_never_zero() -> anyhow::Result<()> {
-        let mut child = std::process::Command::new("sleep").arg("2").spawn()?;
+        let child = SleepChild::spawn("2")?;
         let observer = RunMemoryObserver::attach(child.id());
         std::thread::sleep(std::time::Duration::from_millis(350));
         let observed = observer.finish();
-        child.kill()?;
-        child.wait()?;
 
         if let Some(peak) = observed.max_host_bytes {
             assert!(peak > 0, "a reported peak must never be zero");

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -23,6 +23,11 @@
 //! | Android, Linux | yes | yes | [`proc_footprint`] sampling `/proc/<pid>/status` |
 //! | macOS | yes | no | `phys_footprint`, which already bills compressed pages |
 //! | Windows | no | no | PSAPI reads once after exit through a duplicated handle, so it is not a poller yet |
+//!
+//! The table is this observer's coverage. The `max_memory_usage` benchmark does
+//! not attach one — it already measures memory itself and fills the observation
+//! from that — so its Windows rows do carry a host term, the one place a Windows
+//! row has `observation_max_host_bytes` at all.
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) mod proc_footprint;
@@ -149,6 +154,11 @@ mod tests {
 
     /// The observer must work without the caller knowing which platform it is
     /// on, and must never invent a figure on one that samples nothing.
+    ///
+    /// Unix-gated because it needs a live child to observe and `sleep` is not on
+    /// the PATH of a stock Windows runner — the sampler-less arm this would cover
+    /// there is pinned by `an_arm_with_no_sampler_observes_nothing` instead.
+    #[cfg(unix)]
     #[test]
     fn an_observation_is_either_populated_or_absent_but_never_zero() -> anyhow::Result<()> {
         let mut child = std::process::Command::new("sleep").arg("2").spawn()?;
@@ -174,5 +184,17 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    /// Windows today: attaching still has to succeed so callers need no `cfg`,
+    /// and finishing has to contribute no keys rather than a zero that reads as
+    /// a measurement. Needs no child, since nothing is sampled.
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+    #[test]
+    fn an_arm_with_no_sampler_observes_nothing() {
+        assert_eq!(
+            RunMemoryObserver::attach(std::process::id()).finish(),
+            MemoryObservation::default()
+        );
     }
 }

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -130,12 +130,29 @@ impl RunMemoryObserver {
             #[cfg(target_os = "macos")]
             Inner::PhysFootprint(poller) => poller
                 .stop_and_join()
-                .map(MemoryObservation::host_only)
+                .map(observation_from_phys)
                 .unwrap_or_default(),
             #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
             Inner::Unobserved => MemoryObservation::default(),
         }
     }
+}
+
+/// What a `phys_footprint` reading is worth reporting as, or nothing.
+///
+/// The macOS counterpart of [`observation_from`], applying the same rule: the
+/// read taken as the poller starts happens before the child has loaded
+/// anything, so a footprint built only from it describes startup rather than the
+/// run. `phys_footprint` being a watermark does not help here — the watermark is
+/// simply small that early.
+#[cfg(target_os = "macos")]
+fn observation_from_phys(
+    footprint: pipette_memprobe_metal::host::PhysFootprint,
+) -> MemoryObservation {
+    if footprint.samples < 2 {
+        return MemoryObservation::default();
+    }
+    MemoryObservation::host_only(footprint.peak_bytes)
 }
 
 /// What a `/proc` footprint is worth reporting as, or nothing.
@@ -191,6 +208,31 @@ mod tests {
         assert_eq!(observation_from(&footprint), expected);
     }
 
+    /// The macOS arm needs the same rule as the `/proc` one: the read taken as
+    /// the poller starts describes startup, so a footprint built only from it is
+    /// withheld rather than reported as a measurement.
+    #[cfg(target_os = "macos")]
+    #[rstest::rstest]
+    #[case::seed_only_is_withheld(3_000_000, 1, MemoryObservation::default())]
+    #[case::nothing_read_is_withheld(0, 0, MemoryObservation::default())]
+    #[case::a_zero_peak_is_withheld_even_when_sampled(0, 5, MemoryObservation::default())]
+    #[case::a_post_seed_read_is_reported(
+        6_594_494_464,
+        2,
+        MemoryObservation::host_only(6_594_494_464)
+    )]
+    fn a_phys_observation_needs_a_read_after_the_first(
+        #[case] peak_bytes: u64,
+        #[case] samples: u32,
+        #[case] expected: MemoryObservation,
+    ) {
+        let footprint = pipette_memprobe_metal::host::PhysFootprint {
+            peak_bytes,
+            samples,
+        };
+        assert_eq!(observation_from_phys(footprint), expected);
+    }
+
     /// The observer must work without the caller knowing which platform it is
     /// on, and must never invent a figure on one that samples nothing.
     ///
@@ -207,12 +249,6 @@ mod tests {
 
         if let Some(peak) = observed.max_host_bytes {
             assert!(peak > 0, "a reported peak must never be zero");
-            if let Some(swap) = observed.max_swap_bytes {
-                assert!(
-                    swap <= peak,
-                    "swap is contained in the peak, not added to it"
-                );
-            }
         } else {
             assert_eq!(
                 observed,

--- a/crates/pipette-llamacpp/src/run_memory/mod.rs
+++ b/crates/pipette-llamacpp/src/run_memory/mod.rs
@@ -1,0 +1,178 @@
+//! What memory a run held while it ran, observed for **every** benchmark rather
+//! than only the memory one.
+//!
+//! This is the observation channel, not the metric one: a
+//! [`MemoryObservation`] qualifies a row instead of scoring it, the way
+//! `observation_vl_throughput_prefill_tokens` records the tokens a VL run
+//! actually processed. A decode-throughput number measured while zram held part
+//! of the model is a different fact from one measured resident, and without this
+//! nothing in the row distinguishes them.
+//!
+//! Because it never feeds a scored figure, this is free to report the
+//! swap-aware peak wherever the sampler supplies one. The `max_memory_usage`
+//! metric keeps its own per-arm definition (Linux still reports resident-only
+//! there); the two are allowed to disagree, and that disagreement is exactly
+//! what the swap term explains.
+//!
+//! Attaching is per OS and by design incomplete: an arm with no sampler
+//! observes nothing and contributes no keys, which is why every field is
+//! optional and absence never means zero.
+//!
+//! | Platform | host peak | swap | source |
+//! |---|---|---|---|
+//! | Android, Linux | yes | yes | [`proc_footprint`] sampling `/proc/<pid>/status` |
+//! | macOS | yes | no | `phys_footprint`, which already bills compressed pages |
+//! | Windows | no | no | PSAPI reads once after exit through a duplicated handle, so it is not a poller yet |
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) mod proc_footprint;
+
+use pipette_plan_types::result::MemoryObservation;
+
+/// Observes a spawned child until [`Self::finish`]. Attach right after spawn;
+/// finish after the child is waited for.
+///
+/// Dropping without finishing stops the sampler but discards what it saw, which
+/// is the right outcome on a path that will not report a row.
+pub(crate) struct RunMemoryObserver {
+    inner: Inner,
+}
+
+/// Per-OS backing. A platform with no sampler still gets an observer so callers
+/// need no `cfg` of their own.
+enum Inner {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    Proc(proc_footprint::FootprintPoller),
+    #[cfg(target_os = "macos")]
+    PhysFootprint(pipette_memprobe_metal::host::PhysFootprintPoller),
+    /// Windows today, plus any target without a sampler. Gated to exactly those
+    /// targets: on an arm that does sample, an `Unobserved` that can never be
+    /// constructed is a variant claiming a state the code cannot reach.
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+    Unobserved,
+}
+
+impl RunMemoryObserver {
+    /// Start observing `pid`.
+    pub(crate) fn attach(pid: u32) -> Self {
+        // Both arms poll at the observation cadence, not the memory benchmark's:
+        // a benchmark that reports time must not move because we watched it. See
+        // `OBSERVATION_INTERVAL` for what that costs and why 100 ms rather than
+        // something rarer.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let inner = Inner::Proc(proc_footprint::spawn_observation_poller(pid));
+        #[cfg(target_os = "macos")]
+        let inner = Inner::PhysFootprint(
+            pipette_memprobe_metal::host::spawn_phys_footprint_poller_for_observation(pid as i32),
+        );
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+        let inner = {
+            let _ = pid;
+            Inner::Unobserved
+        };
+        Self { inner }
+    }
+
+    /// Stop observing and report what was seen.
+    ///
+    /// A sampler that failed yields an empty observation rather than an error: an
+    /// observation missing from a row costs a diagnostic, while failing the run
+    /// would discard a benchmark result that is itself perfectly good. The
+    /// memory *metric* makes the opposite trade and refuses to submit a figure
+    /// it cannot trust.
+    pub(crate) fn finish(self) -> MemoryObservation {
+        match self.inner {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            Inner::Proc(poller) => observation_from(&poller.stop_and_join()),
+            #[cfg(target_os = "macos")]
+            Inner::PhysFootprint(poller) => match poller.stop_and_join() {
+                Ok(0) | Err(_) => MemoryObservation::default(),
+                Ok(bytes) => MemoryObservation {
+                    max_host_bytes: Some(bytes),
+                    // `phys_footprint` bills compressed pages to the process, so
+                    // the peak already counts them and no separate term exists.
+                    max_swap_bytes: None,
+                },
+            },
+            #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+            Inner::Unobserved => MemoryObservation::default(),
+        }
+    }
+}
+
+/// What a `/proc` footprint is worth reporting as, or nothing.
+///
+/// Separate from [`RunMemoryObserver::finish`] so the rule is decidable from a
+/// hand-built footprint instead of only from a live process.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn observation_from(footprint: &proc_footprint::Footprint) -> MemoryObservation {
+    // A zero peak means nobody looked. A seed-only footprint is worse: it
+    // describes process startup in a few plausible-looking MB that a consumer
+    // cannot tell apart from a real measurement. Absence is filterable, a wrong
+    // number is not.
+    if footprint.peak_ram_kib() == 0 || footprint.samples < 2 {
+        return MemoryObservation::default();
+    }
+    MemoryObservation {
+        max_host_bytes: Some(footprint.peak_ram_kib().saturating_mul(1024)),
+        max_swap_bytes: Some(footprint.max_swap_bytes()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The seed is taken before the child has loaded anything, so a footprint
+    /// built only from it describes startup, not the run. Reporting it would put
+    /// a few MB on a row as though measured; these cases pin that it is withheld.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[rstest::rstest]
+    #[case::seed_only_is_withheld(3_000, 1, None)]
+    #[case::nothing_read_is_withheld(0, 0, None)]
+    #[case::a_post_seed_read_is_reported(6_440_000, 2, Some(6_440_000 * 1024))]
+    fn an_observation_needs_a_read_after_the_seed(
+        #[case] peak_rss_kib: u64,
+        #[case] samples: u32,
+        #[case] expected_host_bytes: Option<u64>,
+    ) {
+        let footprint = proc_footprint::Footprint {
+            peak_rss_kib,
+            samples,
+            ..Default::default()
+        };
+        assert_eq!(
+            observation_from(&footprint).max_host_bytes,
+            expected_host_bytes
+        );
+    }
+
+    /// The observer must work without the caller knowing which platform it is
+    /// on, and must never invent a figure on one that samples nothing.
+    #[test]
+    fn an_observation_is_either_populated_or_absent_but_never_zero() -> anyhow::Result<()> {
+        let mut child = std::process::Command::new("sleep").arg("2").spawn()?;
+        let observer = RunMemoryObserver::attach(child.id());
+        std::thread::sleep(std::time::Duration::from_millis(350));
+        let observed = observer.finish();
+        child.kill()?;
+        child.wait()?;
+
+        if let Some(peak) = observed.max_host_bytes {
+            assert!(peak > 0, "a reported peak must never be zero");
+            if let Some(swap) = observed.max_swap_bytes {
+                assert!(
+                    swap <= peak,
+                    "swap is contained in the peak, not added to it"
+                );
+            }
+        } else {
+            assert_eq!(
+                observed,
+                MemoryObservation::default(),
+                "an arm with no host peak must report no swap either"
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
+++ b/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
@@ -111,9 +111,11 @@ impl Footprint {
 
     /// The swap term in bytes, for the run's `observation_max_swap_bytes`.
     ///
-    /// Contained in [`Self::peak_ram_kib`] rather than additional to it, so a
-    /// consumer must never sum the two. Zero is a real reading: the sampler
-    /// looked and the run stayed resident.
+    /// Contained in [`Self::peak_ram_kib`], the swap-aware sum, rather than
+    /// additional to it. It is *not* contained in [`Self::peak_rss_kib`], which
+    /// is what the observation reports as its host term: those two are
+    /// independent readings and summing them describes no instant that happened.
+    /// Zero is a real reading: the sampler looked and the run stayed resident.
     pub(crate) fn max_swap_bytes(&self) -> u64 {
         self.max_swap_kib.saturating_mul(1024)
     }

--- a/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
+++ b/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
@@ -231,26 +231,11 @@ const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10
 /// riding along on a benchmark that measures something else.
 ///
 /// A timing benchmark's number must not move because we watched it, so this
-/// trades resolution the observation does not need for a duty cycle that cannot
-/// register: two small reads every 100 ms is ~0.1% of one core, a tenth of
-/// [`SAMPLE_INTERVAL`]'s.
-///
-/// **A watermark still has to be read while the process is alive.** `VmHWM` is
-/// maintained by the kernel, so we never have to catch the peak's instant — but
-/// a process that has exited publishes no `Vm*` fields at all, so the last
-/// useful read precedes exit and anything the run grows in the final interval is
-/// missed. That is the real cost of polling less often, and it is why this is
-/// 100 ms rather than the 500 ms that perturbs even less: past ~100 ms the
-/// saving is immaterial (0.1% vs 0.02% of a core, both far under a benchmark's
-/// noise) while the miss window grows in proportion.
-///
-/// Within that bound the terms still degrade unevenly. `VmHWM` is exact as of
-/// the last read, so cadence costs nothing for a workload whose peak is at model
-/// load, which is every benchmark here. Only the swap-aware uplift and the swap
-/// term itself are additionally sampled between reads, and an observation asks
-/// "did this run swap, and roughly how much",
-/// which a coarse maximum answers. Precision there belongs to the memory
-/// benchmark, which keeps [`SAMPLE_INTERVAL`].
+/// costs a tenth of [`SAMPLE_INTERVAL`]'s duty cycle (~0.1% of one core). Not
+/// rarer, because `VmHWM` has to be read while the process is alive: the last
+/// useful read precedes exit, and that miss window grows in proportion while the
+/// saving past ~100 ms does not. What each term gives up is worked through in
+/// docs/methodology/peak-memory-usage.md.
 const OBSERVATION_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Sample `pid`'s footprint until stopped, at the resolution the memory
@@ -294,6 +279,7 @@ fn spawn_footprint_poller_every(pid: u32, interval: std::time::Duration) -> Foot
             // stop the poller BEFORE reaping (the VL runner does); for the
             // wait_with_output-style callers the window is accepted as not
             // worth guarding.
+            //
             // Sleeps before reading, not after. The seed already covers t=0, so a
             // read-first loop only duplicated it, and sleeping first makes
             // `samples > 1` mean "something was read after a full interval
@@ -339,7 +325,7 @@ mod tests {
     /// set: the thread's own `Arc` clone is released only as it exits.
     #[test]
     fn dropping_a_poller_ends_its_thread() -> anyhow::Result<()> {
-        let mut child = std::process::Command::new("sleep").arg("30").spawn()?;
+        let child = crate::run_memory::SleepChild::spawn("30")?;
         let poller = spawn_footprint_poller_every(child.id(), std::time::Duration::from_millis(5));
         let stop = std::sync::Arc::clone(&poller.stop);
         drop(poller);
@@ -351,8 +337,6 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(5));
             false
         });
-        child.kill()?;
-        child.wait()?;
 
         assert!(
             stop.load(std::sync::atomic::Ordering::Relaxed),
@@ -451,12 +435,10 @@ mod tests {
     /// the sampler must report a live process rather than the default.
     #[test]
     fn the_poller_reports_the_process_it_was_pointed_at() -> anyhow::Result<()> {
-        let mut child = std::process::Command::new("sleep").arg("2").spawn()?;
+        let child = crate::run_memory::SleepChild::spawn("2")?;
         let poller = spawn_footprint_poller(child.id());
         std::thread::sleep(std::time::Duration::from_millis(120));
         let footprint = poller.stop_and_join();
-        child.kill()?;
-        child.wait()?;
 
         assert!(
             footprint.peak_rss_kib > 0,

--- a/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
+++ b/crates/pipette-llamacpp/src/run_memory/proc_footprint.rs
@@ -74,20 +74,27 @@ fn parse_stat_fields(stat: &str) -> Option<(u64, u64)> {
 /// What a run required at peak, kept decomposed so a peak suppressed by reclaim
 /// is visible rather than silently low.
 #[derive(Clone, Copy, Default)]
-pub(super) struct Footprint {
+pub(crate) struct Footprint {
     /// Kernel peak-RSS watermark — exact, but blind to anything in swap.
-    pub(super) peak_rss_kib: u64,
+    pub(crate) peak_rss_kib: u64,
     /// Largest `VmRSS + VmSwap` sampled. The kernel keeps no watermark for
     /// swap, so a sampled maximum is the only way to count what zram holds.
-    pub(super) peak_committed_kib: u64,
+    pub(crate) peak_committed_kib: u64,
     /// How much of the process zram held, and how hard it thrashed to get it
     /// back. Diagnostics: they explain a low `peak_rss_kib`, never replace it.
-    pub(super) max_swap_kib: u64,
-    pub(super) major_faults: u64,
+    pub(crate) max_swap_kib: u64,
+    pub(crate) major_faults: u64,
+    /// How many reads landed. `1` means only the synchronous seed did, taken
+    /// before the child had loaded anything, so the figures describe process
+    /// startup rather than the run: a few MB, non-zero, and indistinguishable
+    /// from a real measurement once submitted. Consumers that would rather report
+    /// nothing than that check this.
+    pub(crate) samples: u32,
 }
 
 impl Footprint {
     fn observe(&mut self, sample: StatusSample) {
+        self.samples = self.samples.saturating_add(1);
         self.peak_rss_kib = self.peak_rss_kib.max(sample.hwm_kib);
         self.peak_committed_kib = self
             .peak_committed_kib
@@ -98,9 +105,17 @@ impl Footprint {
 
     /// Peak RAM the run required, wherever those pages sat when the peak was
     /// struck.
-    #[cfg_attr(not(target_os = "android"), allow(dead_code))]
-    pub(super) fn peak_ram_kib(&self) -> u64 {
+    pub(crate) fn peak_ram_kib(&self) -> u64 {
         self.peak_rss_kib.max(self.peak_committed_kib)
+    }
+
+    /// The swap term in bytes, for the run's `observation_max_swap_bytes`.
+    ///
+    /// Contained in [`Self::peak_ram_kib`] rather than additional to it, so a
+    /// consumer must never sum the two. Zero is a real reading: the sampler
+    /// looked and the run stayed resident.
+    pub(crate) fn max_swap_bytes(&self) -> u64 {
+        self.max_swap_kib.saturating_mul(1024)
     }
 }
 
@@ -114,7 +129,7 @@ impl Footprint {
 /// rather than in `max_memory_usage::android` so its tests run on a target CI
 /// actually executes tests for.
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
-pub(super) fn peak_ram_bytes(
+pub(crate) fn peak_ram_bytes(
     footprint: &Footprint,
     model_path: &std::path::Path,
     flags: &pipette_plan_types::RuntimeFlags,
@@ -177,24 +192,80 @@ fn same_process(identity: Option<u64>, sample_start_time: u64) -> bool {
     }
 }
 
-pub(super) struct FootprintPoller {
+pub(crate) struct FootprintPoller {
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    handle: std::thread::JoinHandle<Footprint>,
+    /// `Option` only so [`Drop`] can coexist with a `stop_and_join` that moves
+    /// the handle out to join it.
+    handle: Option<std::thread::JoinHandle<Footprint>>,
 }
 
-/// How often the sampler reads `/proc/<pid>`.
+impl Drop for FootprintPoller {
+    /// Setting the flag is the only thing that ends the sampling thread, and
+    /// `stop_and_join` consumes `self`, so this runs exactly on the paths that
+    /// discard the observation: a run that failed before reporting, or a
+    /// `llama-server` replaced mid-eval after a crash. Without it each of those
+    /// leaves a thread waking forever to read the `/proc` entry of a dead pid.
+    ///
+    /// Deliberately does not join. This runs on error paths, and blocking one
+    /// for up to a full sample interval to collect a footprint nobody will read
+    /// is not worth it; the thread observes the flag and exits on its own.
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// How often the sampler reads `/proc/<pid>` when the figure it produces is the
+/// benchmark's own result.
 ///
 /// This bounds the only lossy term. `VmHWM` is exact, but when swap suppresses it
 /// the reported figure falls back to the sampled `VmRSS + VmSwap` sum, which can
 /// only under-read: the miss is roughly the footprint's growth rate times this
 /// interval. A no-mmap load faults in ~900 MB/s, so 10 ms costs about 9 MB of
 /// resolution where 25 ms cost ~22 MB. Two small reads per tick at 100 Hz is
-/// ~1% of one core, which stays clear of perturbing a benchmark that already has
-/// four threads running.
+/// ~1% of one core, which the memory benchmark can afford because it reports
+/// bytes, not time. A benchmark that reports time must not pay it: see
+/// [`OBSERVATION_INTERVAL`].
 const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 
-/// Sample `pid`'s footprint until stopped.
-pub(super) fn spawn_footprint_poller(pid: u32) -> FootprintPoller {
+/// How often to read `/proc/<pid>` when the figure is only an observation
+/// riding along on a benchmark that measures something else.
+///
+/// A timing benchmark's number must not move because we watched it, so this
+/// trades resolution the observation does not need for a duty cycle that cannot
+/// register: two small reads every 100 ms is ~0.1% of one core, a tenth of
+/// [`SAMPLE_INTERVAL`]'s.
+///
+/// **A watermark still has to be read while the process is alive.** `VmHWM` is
+/// maintained by the kernel, so we never have to catch the peak's instant — but
+/// a process that has exited publishes no `Vm*` fields at all, so the last
+/// useful read precedes exit and anything the run grows in the final interval is
+/// missed. That is the real cost of polling less often, and it is why this is
+/// 100 ms rather than the 500 ms that perturbs even less: past ~100 ms the
+/// saving is immaterial (0.1% vs 0.02% of a core, both far under a benchmark's
+/// noise) while the miss window grows in proportion.
+///
+/// Within that bound the terms still degrade unevenly. `VmHWM` is exact as of
+/// the last read, so cadence costs nothing for a workload whose peak is at model
+/// load, which is every benchmark here. Only the swap-aware uplift and the swap
+/// term itself are additionally sampled between reads, and an observation asks
+/// "did this run swap, and roughly how much",
+/// which a coarse maximum answers. Precision there belongs to the memory
+/// benchmark, which keeps [`SAMPLE_INTERVAL`].
+const OBSERVATION_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Sample `pid`'s footprint until stopped, at the resolution the memory
+/// benchmark's own metric needs.
+pub(crate) fn spawn_footprint_poller(pid: u32) -> FootprintPoller {
+    spawn_footprint_poller_every(pid, SAMPLE_INTERVAL)
+}
+
+/// Sample `pid`'s footprint until stopped, at the cadence for an observation on
+/// a benchmark measuring something else. See [`OBSERVATION_INTERVAL`].
+pub(crate) fn spawn_observation_poller(pid: u32) -> FootprintPoller {
+    spawn_footprint_poller_every(pid, OBSERVATION_INTERVAL)
+}
+
+fn spawn_footprint_poller_every(pid: u32, interval: std::time::Duration) -> FootprintPoller {
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -223,32 +294,73 @@ pub(super) fn spawn_footprint_poller(pid: u32) -> FootprintPoller {
             // stop the poller BEFORE reaping (the VL runner does); for the
             // wait_with_output-style callers the window is accepted as not
             // worth guarding.
+            // Sleeps before reading, not after. The seed already covers t=0, so a
+            // read-first loop only duplicated it, and sleeping first makes
+            // `samples > 1` mean "something was read after a full interval
+            // elapsed" — the distinction `Footprint::samples` exists to carry.
             while !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(interval);
                 if let Some(sample) = read_status_sample(pid) {
                     if same_process(identity, sample.start_time) {
                         footprint.observe(sample);
                     }
                 }
-                std::thread::sleep(SAMPLE_INTERVAL);
             }
             footprint
         })
     };
-    FootprintPoller { stop, handle }
+    FootprintPoller {
+        stop,
+        handle: Some(handle),
+    }
 }
 
 impl FootprintPoller {
     /// Stop the poller and return what it saw. A sampler that panicked yields
     /// the default, whose zero peak the callers reject rather than submit.
-    pub(super) fn stop_and_join(self) -> Footprint {
+    pub(crate) fn stop_and_join(mut self) -> Footprint {
         self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
-        self.handle.join().unwrap_or_default()
+        self.handle
+            .take()
+            .map(|handle| handle.join().unwrap_or_default())
+            .unwrap_or_default()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A poller dropped without `stop_and_join` must still end its thread.
+    /// Nothing but the flag stops it, and the observer is dropped un-finished on
+    /// every failed run and every `llama-server` replaced mid-eval, so a missing
+    /// `Drop` leaks one thread per occurrence, each waking forever to read a dead
+    /// pid. Asserts the thread actually observes the flag, not merely that it was
+    /// set: the thread's own `Arc` clone is released only as it exits.
+    #[test]
+    fn dropping_a_poller_ends_its_thread() -> anyhow::Result<()> {
+        let mut child = std::process::Command::new("sleep").arg("30").spawn()?;
+        let poller = spawn_footprint_poller_every(child.id(), std::time::Duration::from_millis(5));
+        let stop = std::sync::Arc::clone(&poller.stop);
+        drop(poller);
+
+        let exited = (0..200).any(|_| {
+            if std::sync::Arc::strong_count(&stop) == 1 {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            false
+        });
+        child.kill()?;
+        child.wait()?;
+
+        assert!(
+            stop.load(std::sync::atomic::Ordering::Relaxed),
+            "drop must signal the sampler to stop"
+        );
+        assert!(exited, "the sampling thread outlived the dropped poller");
+        Ok(())
+    }
 
     /// `comm` is attacker-shaped: it can hold spaces and parens, so both fields
     /// have to be located from the last ')' rather than by absolute token index.

--- a/crates/pipette-llamacpp/src/server.rs
+++ b/crates/pipette-llamacpp/src/server.rs
@@ -27,6 +27,40 @@ pub struct RunningLlamaServer {
     /// registry. Drop on the field auto-deregisters; the test-only
     /// construction site below leaves it `None`.
     _cleanup_guard: Option<pipette_subprocess::cleanup::Guard>,
+    /// Observes the server's memory for the run's `observation_max_*` fields.
+    /// `None` until a caller opts in via [`Self::observe_memory`], and taken by
+    /// [`Self::memory_observation`] so an observation is reported once.
+    memory_observer: Option<crate::run_memory::RunMemoryObserver>,
+}
+
+impl RunningLlamaServer {
+    /// Start observing this server's memory for the run's `observation_max_*`
+    /// fields. Opt-in rather than done by [`start`]: `eval` reports no
+    /// observation (it can restart the server mid-run, so no single figure
+    /// describes the whole run) and would otherwise pay for a sampler whose
+    /// result is discarded, across a run that can last hours.
+    ///
+    /// Call right after `start`. The peak counters are watermarks, so attaching a
+    /// moment late still sees a peak already reached.
+    pub fn observe_memory(&mut self) {
+        self.memory_observer = Some(crate::run_memory::RunMemoryObserver::attach(
+            self.child.id(),
+        ));
+    }
+
+    /// The memory this server held, for the run's observation fields. Empty
+    /// unless [`Self::observe_memory`] was called. Taking it finishes the
+    /// sampler, so a second call reports nothing observed rather than a second
+    /// reading.
+    ///
+    /// Safe to call after the child is reaped: the sampler has already
+    /// accumulated its peak and later reads simply find no `/proc` entry.
+    pub fn memory_observation(&mut self) -> pipette_plan_types::result::MemoryObservation {
+        self.memory_observer
+            .take()
+            .map(|observer| observer.finish())
+            .unwrap_or_default()
+    }
 }
 
 impl Drop for RunningLlamaServer {
@@ -186,6 +220,7 @@ pub fn start(
         stderr_buf,
         stderr_thread: Some(stderr_thread),
         _cleanup_guard: Some(cleanup_guard),
+        memory_observer: None,
     })
 }
 
@@ -385,6 +420,7 @@ mod tests {
             stderr_buf,
             stderr_thread: Some(stderr_thread),
             _cleanup_guard: None,
+            memory_observer: None,
         };
         let stderr = shutdown_and_collect_stderr(&mut server);
 

--- a/crates/pipette-memprobe-metal/README.md
+++ b/crates/pipette-memprobe-metal/README.md
@@ -82,7 +82,8 @@ that path) still surface the peak.
 pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller;
 pub fn spawn_phys_footprint_poller_for_observation(pid: i32) -> PhysFootprintPoller;
 pub struct PhysFootprintPoller { /* opaque */ }
-impl PhysFootprintPoller { pub fn stop_and_join(self) -> u64; }
+pub struct PhysFootprint { pub peak_bytes: u64, pub samples: u32 }
+impl PhysFootprintPoller { pub fn stop_and_join(self) -> anyhow::Result<PhysFootprint>; }
 ```
 
 Polls `proc_pid_rusage(pid, RUSAGE_INFO_V4)` every 20 ms while the
@@ -131,7 +132,7 @@ cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 let child = cmd.spawn()?;
 let phys_poller = host::spawn_phys_footprint_poller(child.id() as i32);
 let output = child.wait_with_output()?;
-let phys_peak = phys_poller.stop_and_join();
+let phys_peak = phys_poller.stop_and_join()?.peak_bytes;
 
 // Read shim snapshot. Each peak is reported independently — no
 // cross-subtraction. On UMA the two values overlap (Metal lives

--- a/crates/pipette-memprobe-metal/README.md
+++ b/crates/pipette-memprobe-metal/README.md
@@ -80,6 +80,7 @@ that path) still surface the peak.
 
 ```rust
 pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller;
+pub fn spawn_phys_footprint_poller_for_observation(pid: i32) -> PhysFootprintPoller;
 pub struct PhysFootprintPoller { /* opaque */ }
 impl PhysFootprintPoller { pub fn stop_and_join(self) -> u64; }
 ```
@@ -92,6 +93,14 @@ high-water mark** maintained inside the kernel: even if the
 20 ms poll misses a sub-poll spike, the next poll observes the
 elevated lifetime max. The 20 ms cadence is therefore latency for
 detection, not for accuracy.
+
+That is why `spawn_phys_footprint_poller_for_observation` exists: a caller
+that only wants an observation alongside a benchmark reporting time
+polls every 100 ms and still reads the same watermark rather than
+having to catch the peak's instant. It is not free, though --
+`proc_pid_rusage` returns ESRCH once the child is reaped, so the last
+useful read precedes exit and a peak reached in the final interval is
+missed.
 
 The poller's value is reported **directly** as `max_host_bytes`.
 On Apple UMA, Metal allocations are billed to `phys_footprint`, so

--- a/crates/pipette-memprobe-metal/src/host.rs
+++ b/crates/pipette-memprobe-metal/src/host.rs
@@ -72,7 +72,29 @@ impl PhysFootprintPoller {
 /// if a future workload allocates and frees within a frame. See
 /// `pipette-mgmt/docs/methodology/peak-memory.md` §3.1 for the
 /// failure-detection signal.
+///
+/// A caller riding along on a benchmark that reports *time* should use
+/// [`spawn_phys_footprint_poller_for_observation`] instead, which polls rarely
+/// enough not to move the number it observes.
 pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller {
+    spawn_phys_footprint_poller_every(pid, Duration::from_millis(20))
+}
+
+/// As [`spawn_phys_footprint_poller`], but for a caller whose benchmark reports
+/// time rather than bytes, where the poller must not be able to move the number
+/// it rides along with.
+///
+/// `ri_lifetime_max_phys_footprint` is a kernel-maintained high-water mark, so a
+/// rarer poll still reads the same peak rather than needing to catch its instant.
+/// It does **not** make the cadence free: `proc_pid_rusage` returns ESRCH once
+/// the child is reaped, so the last useful read precedes exit and a peak reached
+/// in the final interval is missed. 100 ms bounds that window while costing
+/// ~0.1% of a core.
+pub fn spawn_phys_footprint_poller_for_observation(pid: i32) -> PhysFootprintPoller {
+    spawn_phys_footprint_poller_every(pid, Duration::from_millis(100))
+}
+
+fn spawn_phys_footprint_poller_every(pid: i32, interval: Duration) -> PhysFootprintPoller {
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
     let handle = thread::spawn(move || -> u64 {
         let mut peak: u64 = 0;
@@ -98,8 +120,8 @@ pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller {
             // child. Fine — peak is captured; loop until stop.
             //
             // Combined sleep + stop-check: recv_timeout sleeps up to
-            // 20 ms, returns early on stop signal or sender drop.
-            match stop_rx.recv_timeout(Duration::from_millis(20)) {
+            // `interval`, returns early on stop signal or sender drop.
+            match stop_rx.recv_timeout(interval) {
                 Ok(_) | Err(RecvTimeoutError::Disconnected) => break peak,
                 Err(RecvTimeoutError::Timeout) => continue,
             }

--- a/crates/pipette-memprobe-metal/src/host.rs
+++ b/crates/pipette-memprobe-metal/src/host.rs
@@ -77,7 +77,7 @@ impl PhysFootprintPoller {
 /// [`spawn_phys_footprint_poller_for_observation`] instead, which polls rarely
 /// enough not to move the number it observes.
 pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller {
-    spawn_phys_footprint_poller_every(pid, Duration::from_millis(20))
+    spawn_phys_footprint_poller_every(pid, SAMPLE_INTERVAL)
 }
 
 /// As [`spawn_phys_footprint_poller`], but for a caller whose benchmark reports
@@ -91,8 +91,18 @@ pub fn spawn_phys_footprint_poller(pid: i32) -> PhysFootprintPoller {
 /// in the final interval is missed. 100 ms bounds that window while costing
 /// ~0.1% of a core.
 pub fn spawn_phys_footprint_poller_for_observation(pid: i32) -> PhysFootprintPoller {
-    spawn_phys_footprint_poller_every(pid, Duration::from_millis(100))
+    spawn_phys_footprint_poller_every(pid, OBSERVATION_INTERVAL)
 }
+
+/// Cadence when the peak *is* the benchmark's result. Sufficient for
+/// steady-state peaks; tighten only if a future workload allocates and frees
+/// within a frame.
+const SAMPLE_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Cadence when the peak only rides along on a benchmark reporting time, chosen
+/// so the poller cannot move that number. Mirrors the `/proc` sampler's split in
+/// `pipette-llamacpp`'s `run_memory::proc_footprint`.
+const OBSERVATION_INTERVAL: Duration = Duration::from_millis(100);
 
 fn spawn_phys_footprint_poller_every(pid: i32, interval: Duration) -> PhysFootprintPoller {
     let (stop_tx, stop_rx) = mpsc::channel::<()>();

--- a/crates/pipette-memprobe-metal/src/host.rs
+++ b/crates/pipette-memprobe-metal/src/host.rs
@@ -48,11 +48,12 @@ pub struct PhysFootprint {
     pub peak_bytes: u64,
     /// How many `proc_pid_rusage` calls returned a reading.
     ///
-    /// `1` means only the read taken as the thread started did, before the
-    /// child had loaded anything: a few plausible-looking MB of process startup
-    /// that a consumer cannot tell apart from a measurement. A caller that would
-    /// rather report nothing than that checks this — the `/proc` sampler carries
-    /// the same count for the same reason.
+    /// `1` usually means only the read taken as the thread started did, before
+    /// the child had loaded anything: a few plausible-looking MB of process
+    /// startup that a consumer cannot tell apart from a measurement. A caller
+    /// that would rather report nothing than that checks this. Only "usually"
+    /// because that first read happens when the thread is scheduled rather than
+    /// synchronously at spawn, so a short run can land its one sample later.
     pub samples: u32,
 }
 

--- a/crates/pipette-memprobe-metal/src/host.rs
+++ b/crates/pipette-memprobe-metal/src/host.rs
@@ -37,7 +37,23 @@ use std::{
               dropping the handle silently discards the measurement"]
 pub struct PhysFootprintPoller {
     stop: mpsc::Sender<()>,
-    handle: JoinHandle<u64>,
+    handle: JoinHandle<PhysFootprint>,
+}
+
+/// What a poller saw: the peak, and how many reads produced it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PhysFootprint {
+    /// Largest `phys_footprint` observed, in bytes. Zero means no read
+    /// succeeded.
+    pub peak_bytes: u64,
+    /// How many `proc_pid_rusage` calls returned a reading.
+    ///
+    /// `1` means only the read taken as the thread started did, before the
+    /// child had loaded anything: a few plausible-looking MB of process startup
+    /// that a consumer cannot tell apart from a measurement. A caller that would
+    /// rather report nothing than that checks this — the `/proc` sampler carries
+    /// the same count for the same reason.
+    pub samples: u32,
 }
 
 impl PhysFootprintPoller {
@@ -51,7 +67,7 @@ impl PhysFootprintPoller {
     /// must fail the bench loudly rather than silently report a
     /// partial peak — the caller can't tell the difference between
     /// "zero peak observed" and "panic before any observation."
-    pub fn stop_and_join(self) -> anyhow::Result<u64> {
+    pub fn stop_and_join(self) -> anyhow::Result<PhysFootprint> {
         // Send is non-blocking; the poller's recv_timeout returns Ok
         // on the next tick. Send may fail (Disconnected) if the
         // poller already exited — ignore here; join below surfaces
@@ -106,8 +122,8 @@ const OBSERVATION_INTERVAL: Duration = Duration::from_millis(100);
 
 fn spawn_phys_footprint_poller_every(pid: i32, interval: Duration) -> PhysFootprintPoller {
     let (stop_tx, stop_rx) = mpsc::channel::<()>();
-    let handle = thread::spawn(move || -> u64 {
-        let mut peak: u64 = 0;
+    let handle = thread::spawn(move || -> PhysFootprint {
+        let mut footprint = PhysFootprint::default();
         loop {
             let mut info = MaybeUninit::<libc::rusage_info_v4>::zeroed();
             let rc = unsafe {
@@ -122,9 +138,8 @@ fn spawn_phys_footprint_poller_every(pid: i32, interval: Duration) -> PhysFootpr
                 let observed = info
                     .ri_phys_footprint
                     .max(info.ri_lifetime_max_phys_footprint);
-                if observed > peak {
-                    peak = observed;
-                }
+                footprint.samples = footprint.samples.saturating_add(1);
+                footprint.peak_bytes = footprint.peak_bytes.max(observed);
             }
             // proc_pid_rusage returns ESRCH after wait4 reaps the
             // child. Fine — peak is captured; loop until stop.
@@ -132,7 +147,7 @@ fn spawn_phys_footprint_poller_every(pid: i32, interval: Duration) -> PhysFootpr
             // Combined sleep + stop-check: recv_timeout sleeps up to
             // `interval`, returns early on stop signal or sender drop.
             match stop_rx.recv_timeout(interval) {
-                Ok(_) | Err(RecvTimeoutError::Disconnected) => break peak,
+                Ok(_) | Err(RecvTimeoutError::Disconnected) => break footprint,
                 Err(RecvTimeoutError::Timeout) => continue,
             }
         }

--- a/crates/pipette-mlx/src/execute/max_memory_usage.rs
+++ b/crates/pipette-mlx/src/execute/max_memory_usage.rs
@@ -55,9 +55,12 @@ pub(super) fn run(req: &RunRequest) -> anyhow::Result<RunResponse> {
             decode_tokens: DECODE_TOKENS,
         },
     );
+    // Peak only: this arm polls across the whole load, so the seed-only case the
+    // `samples` count guards against cannot arise here.
     let max_host_bytes = phys_poller
         .stop_and_join()
-        .context("phys_footprint poller failed; max_host_bytes is unreliable")?;
+        .context("phys_footprint poller failed; max_host_bytes is unreliable")?
+        .peak_bytes;
 
     let shutdown_result: anyhow::Result<serde_json::Value> =
         throughput_http::post_json(&server.base_url, SHUTDOWN_ENDPOINT, &serde_json::json!({}));

--- a/crates/pipette-plan-types/src/result.rs
+++ b/crates/pipette-plan-types/src/result.rs
@@ -126,25 +126,36 @@ pub struct BenchmarkEvalCompletion {
 /// populates nothing. Absence means "not observed", never zero.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryObservation {
-    /// Peak memory the run held, counting pages the kernel had compressed or
-    /// paged out where the platform can see them.
+    /// Peak *resident* memory the run held: the kernel's high-water mark for
+    /// the pages actually in RAM.
     ///
-    /// Deliberately *not* the same quantity as the memory benchmark's
-    /// `max_host_bytes` on every arm: this is free to report the swap-aware peak
-    /// wherever the sampler supplies one, because an observation qualifies a row
-    /// rather than being scored. The Linux memory metric stays resident-only.
+    /// Resident-only on every arm that can be, so the name means one thing
+    /// across platforms — `VmHWM` on Android and Linux, `PeakWorkingSetSize` on
+    /// Windows. macOS is the exception it cannot avoid: `phys_footprint` bills
+    /// compressed pages to the process and the kernel publishes no resident-only
+    /// counter beside it.
+    ///
+    /// Pages the kernel swapped out are deliberately **not** counted here. What
+    /// tells a reader this figure was suppressed by reclaim is
+    /// [`Self::max_swap_bytes`] standing beside it.
     #[serde(
         rename = "observation_max_host_bytes",
         default,
         skip_serializing_if = "Option::is_none"
     )]
     pub max_host_bytes: Option<u64>,
-    /// Most of the run the kernel held in swap at once.
+    /// Most the kernel held of this run in swap at once.
     ///
-    /// Contained in [`Self::max_host_bytes`] rather than additional to it, so
-    /// the two are never summed. `Some(0)` is a real reading meaning the
-    /// platform sampled swap and the run stayed resident, which is what makes
-    /// the peak beside it trustworthy; `None` means nothing sampled it.
+    /// A term in its own right, **not** a component of [`Self::max_host_bytes`]
+    /// and not additive with it: the resident watermark and the largest swap
+    /// reading need not fall at the same instant, so their sum describes no
+    /// moment that happened. Read it as the qualifier on the peak beside it —
+    /// a non-zero swap term means the resident figure under-states what the run
+    /// required, and by roughly how much.
+    ///
+    /// `Some(0)` is a real reading, meaning the platform sampled swap and the
+    /// run stayed resident, which is what makes the peak beside it trustworthy;
+    /// `None` means nothing sampled it.
     #[serde(
         rename = "observation_max_swap_bytes",
         default,

--- a/crates/pipette-plan-types/src/result.rs
+++ b/crates/pipette-plan-types/src/result.rs
@@ -264,10 +264,11 @@ impl BenchmarkResultData {
 
 /// Payload sent to the management server via `POST /benchmarks`.
 ///
-/// **Serde note**: this struct uses three `#[serde(flatten)]` fields —
-/// [`DeviceInfo`], [`ThermalTelemetry`], and [`BenchmarkResultData`].  All
-/// field names across the flattened types and the struct itself must remain
-/// unique; a collision silently breaks deserialization.  The round-trip test
+/// **Serde note**: this struct uses four `#[serde(flatten)]` fields —
+/// [`DeviceInfo`], [`ThermalTelemetry`], [`MemoryObservation`], and
+/// [`BenchmarkResultData`].  All field names across the flattened types and the
+/// struct itself must remain unique; a collision silently breaks
+/// deserialization.  The round-trip test
 /// `submission_payload_round_trip_with_device_info` guards this.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BenchmarkSubmissionPayload {

--- a/crates/pipette-plan-types/src/result.rs
+++ b/crates/pipette-plan-types/src/result.rs
@@ -154,6 +154,38 @@ pub struct MemoryObservation {
 }
 
 impl MemoryObservation {
+    /// A peak from a sampler that sees no swap term, or nothing if it read
+    /// nothing.
+    ///
+    /// Zero is how every sampler here spells "no read landed", so it is withheld
+    /// rather than reported: absence is filterable, and a zero on the row reads
+    /// as a measurement. Constructing through this instead of the literal is what
+    /// keeps that rule in one place — the arms that built their own once shipped
+    /// a `Some(0)`.
+    pub fn host_only(host_bytes: u64) -> Self {
+        Self {
+            max_host_bytes: (host_bytes > 0).then_some(host_bytes),
+            max_swap_bytes: None,
+        }
+    }
+
+    /// A peak with the swap term beside it, from a sampler that reads both.
+    ///
+    /// Same rule for the peak, and the swap term rides with it: a withheld peak
+    /// withholds the swap reading too, since half an observation says the
+    /// platform sampled swap while refusing to say what it held. A `Some(0)`
+    /// swap beside a real peak is the opposite — a reading, and the one that
+    /// makes the peak trustworthy.
+    pub fn with_swap(host_bytes: u64, swap_bytes: u64) -> Self {
+        match (host_bytes > 0).then_some(host_bytes) {
+            Some(host_bytes) => Self {
+                max_host_bytes: Some(host_bytes),
+                max_swap_bytes: Some(swap_bytes),
+            },
+            None => Self::default(),
+        }
+    }
+
     /// The larger of two observations, term by term.
     ///
     /// A benchmark that runs several repetitions observes each one, and the run's
@@ -410,6 +442,35 @@ mod tests {
         #[case] expected: MemoryObservation,
     ) {
         assert_eq!(a.merge_max(b), expected);
+    }
+
+    /// The constructors are where the "zero is not a measurement" rule lives, so
+    /// every arm that builds an observation inherits it.
+    #[rstest]
+    #[case::host_only_keeps_a_real_peak(
+        observed(Some(600), None),
+        MemoryObservation::host_only(600)
+    )]
+    #[case::host_only_withholds_a_zero(observed(None, None), MemoryObservation::host_only(0))]
+    // A sampled zero swap is a reading and survives beside a real peak.
+    #[case::swap_zero_is_a_reading(
+        observed(Some(600), Some(0)),
+        MemoryObservation::with_swap(600, 0)
+    )]
+    #[case::swap_rides_with_the_peak(
+        observed(Some(600), Some(50)),
+        MemoryObservation::with_swap(600, 50)
+    )]
+    // Never half an observation: no peak means the swap term goes too.
+    #[case::a_withheld_peak_withholds_swap(
+        observed(None, None),
+        MemoryObservation::with_swap(0, 50)
+    )]
+    fn a_zero_peak_is_withheld_rather_than_reported(
+        #[case] expected: MemoryObservation,
+        #[case] built: MemoryObservation,
+    ) {
+        assert_eq!(built, expected);
     }
 
     /// An observation with nothing in it must contribute no keys, so a client on

--- a/crates/pipette-plan-types/src/result.rs
+++ b/crates/pipette-plan-types/src/result.rs
@@ -109,6 +109,77 @@ pub struct BenchmarkEvalCompletion {
     pub completion_tokens: Option<u64>,
 }
 
+/// What a run's memory looked like while it ran, on every benchmark kind rather
+/// than only the memory one.
+///
+/// These are **observations, not metrics**, in the same sense as
+/// `observation_vl_throughput_prefill_tokens`: measured workload facts that
+/// qualify a result instead of scoring it. A decode-throughput row that hit its
+/// number while zram held part of the model is a different fact from one that
+/// stayed resident, and without this nothing in the row says which happened.
+///
+/// Unlike the `observation_vl_throughput_*` columns these carry no benchmark
+/// prefix, because they are not specific to one benchmark type.
+///
+/// Every field is optional and per platform: a platform with no sampler
+/// contributes no keys, so the wire shape is unchanged for a client that
+/// populates nothing. Absence means "not observed", never zero.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryObservation {
+    /// Peak memory the run held, counting pages the kernel had compressed or
+    /// paged out where the platform can see them.
+    ///
+    /// Deliberately *not* the same quantity as the memory benchmark's
+    /// `max_host_bytes` on every arm: this is free to report the swap-aware peak
+    /// wherever the sampler supplies one, because an observation qualifies a row
+    /// rather than being scored. The Linux memory metric stays resident-only.
+    #[serde(
+        rename = "observation_max_host_bytes",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_host_bytes: Option<u64>,
+    /// Most of the run the kernel held in swap at once.
+    ///
+    /// Contained in [`Self::max_host_bytes`] rather than additional to it, so
+    /// the two are never summed. `Some(0)` is a real reading meaning the
+    /// platform sampled swap and the run stayed resident, which is what makes
+    /// the peak beside it trustworthy; `None` means nothing sampled it.
+    #[serde(
+        rename = "observation_max_swap_bytes",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_swap_bytes: Option<u64>,
+}
+
+impl MemoryObservation {
+    /// The larger of two observations, term by term.
+    ///
+    /// A benchmark that runs several repetitions observes each one, and the run's
+    /// figure is the worst any rep reached: reporting the last rep would hide a
+    /// peak an earlier one hit, and averaging would describe no rep that
+    /// happened. Taken per term rather than by picking a winning observation,
+    /// because the largest peak and the largest swap need not come from the same
+    /// rep.
+    ///
+    /// `None` is "not observed" rather than zero, so it never wins a maximum: an
+    /// arm that sampled one rep and missed another still reports the reading it
+    /// has.
+    pub fn merge_max(self, other: Self) -> Self {
+        fn larger(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+            match (a, b) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (found, None) | (None, found) => found,
+            }
+        }
+        Self {
+            max_host_bytes: larger(self.max_host_bytes, other.max_host_bytes),
+            max_swap_bytes: larger(self.max_swap_bytes, other.max_swap_bytes),
+        }
+    }
+}
+
 /// Result data for a benchmark run.
 ///
 /// **Serde note**: this enum uses `#[serde(untagged)]`, so deserialization tries
@@ -219,6 +290,12 @@ pub struct BenchmarkSubmissionPayload {
     // shape is unchanged for clients that don't populate it.
     #[serde(flatten)]
     pub thermal: ThermalTelemetry,
+    // What memory the run held while it ran, on every benchmark kind. Flattened
+    // beside the thermal and power observations for the same reason: these are
+    // conditions the result was measured under, not the result. See
+    // [`MemoryObservation`].
+    #[serde(flatten)]
+    pub memory: MemoryObservation,
     /// Canonical JSON of the run's `pipette_plan_types::Model` — the lossless
     /// model coordinate (`type`/`source`/`org`/`repo_name`/…). Supersedes the
     /// old `model_name`/`model_quant`/`mmproj_quant` grouping fields; the server
@@ -279,6 +356,70 @@ mod tests {
     use crate::device::DeviceFormFactor;
     use crate::thermal::{LinuxThermalZone, ThermalReading};
     use crate::ModelFlags;
+
+    fn observed(host: Option<u64>, swap: Option<u64>) -> MemoryObservation {
+        MemoryObservation {
+            max_host_bytes: host,
+            max_swap_bytes: swap,
+        }
+    }
+
+    /// Folding across repetitions must keep the worst of each term and must never
+    /// let "not observed" beat a real reading.
+    #[rstest]
+    // The worst rep wins, not the last one.
+    #[case::worst_rep_wins(
+        observed(Some(600), Some(50)),
+        observed(Some(400), Some(10)),
+        observed(Some(600), Some(50))
+    )]
+    // Terms are taken independently: the biggest peak and the biggest swap can
+    // come from different reps, and picking one rep wholesale would lose one.
+    #[case::terms_are_independent(
+        observed(Some(600), Some(10)),
+        observed(Some(400), Some(90)),
+        observed(Some(600), Some(90))
+    )]
+    // `None` is "nobody looked", so a rep that observed nothing must not erase a
+    // rep that did.
+    #[case::absence_never_wins(
+        observed(Some(600), Some(50)),
+        observed(None, None),
+        observed(Some(600), Some(50))
+    )]
+    #[case::absence_never_wins_either_order(
+        observed(None, None),
+        observed(Some(600), Some(50)),
+        observed(Some(600), Some(50))
+    )]
+    // A sampled zero is a real reading and survives, unlike absence.
+    #[case::a_sampled_zero_is_kept(
+        observed(Some(600), Some(0)),
+        observed(None, None),
+        observed(Some(600), Some(0))
+    )]
+    #[case::nothing_observed_stays_empty(
+        observed(None, None),
+        observed(None, None),
+        observed(None, None)
+    )]
+    fn merging_reps_keeps_the_worst_of_each_term(
+        #[case] a: MemoryObservation,
+        #[case] b: MemoryObservation,
+        #[case] expected: MemoryObservation,
+    ) {
+        assert_eq!(a.merge_max(b), expected);
+    }
+
+    /// An observation with nothing in it must contribute no keys, so a client on
+    /// a platform without a sampler leaves the wire shape untouched.
+    #[test]
+    fn an_empty_observation_serializes_to_nothing() -> anyhow::Result<()> {
+        let json = serde_json::to_value(MemoryObservation::default())?;
+        assert_eq!(json, serde_json::json!({}), "got {json}");
+        assert_eq!(MemoryObservation::default(), MemoryObservation::default());
+        Ok(())
+    }
 
     /// Every untagged variant survives a round trip, with and without its
     /// optional stddev.
@@ -525,6 +666,7 @@ mod tests {
             device_power_state: None,
             device_power_save_mode: None,
             thermal: ThermalTelemetry::default(),
+            memory: MemoryObservation::default(),
             model_descriptor: MODEL_DESC.to_string(),
             runtime_descriptor: RT_DESC.to_string(),
             model_flags: None,
@@ -562,6 +704,7 @@ mod tests {
             device_power_state: None,
             device_power_save_mode: None,
             thermal: ThermalTelemetry::default(),
+            memory: MemoryObservation::default(),
             model_descriptor: MODEL_DESC.to_string(),
             runtime_descriptor: RT_DESC.to_string(),
             model_flags: None,
@@ -682,6 +825,10 @@ mod tests {
                     ..Default::default()
                 }],
             ),
+            memory: MemoryObservation {
+                max_host_bytes: Some(6_594_494_464),
+                max_swap_bytes: Some(356_515_840),
+            },
             model_descriptor: MODEL_DESC.to_string(),
             runtime_descriptor: RT_DESC.to_string(),
             model_flags: None,
@@ -707,6 +854,16 @@ mod tests {
         assert_eq!(json["device_linux_thermal_zones_before"][2]["iteration"], 1);
         assert_eq!(json["device_linux_thermal_zones_before"][2]["celsius"], 55);
         assert!(json.get("thermal").is_none());
+        // The memory observation flattens the same way, under the
+        // `observation_*` names the warehouse uses for measured workload facts.
+        // Note this is a decode-throughput row: the observation rides on every
+        // benchmark, not just the memory one.
+        assert_eq!(json["observation_max_host_bytes"], 6_594_494_464u64);
+        assert_eq!(json["observation_max_swap_bytes"], 356_515_840u64);
+        assert!(
+            json.get("memory").is_none(),
+            "must flatten, not nest: {json}"
+        );
         let round_tripped: BenchmarkSubmissionPayload = serde_json::from_value(json)?;
         assert_eq!(round_tripped, payload);
         Ok(())

--- a/crates/pipette-plan-types/src/run.rs
+++ b/crates/pipette-plan-types/src/run.rs
@@ -20,7 +20,7 @@
 use serde::Serialize;
 
 use crate::benchmark::BenchmarkDefinition;
-use crate::result::BenchmarkResultData;
+use crate::result::{BenchmarkResultData, MemoryObservation};
 use crate::thermal::RunThermal;
 use crate::{
     BenchmarkFlagRef, BenchmarkFlags, Model, ModelFlags, ModelType, Runtime, RuntimeFlagRef,
@@ -160,6 +160,15 @@ pub struct RunResponse {
     /// (see [`RuntimeFlags::submission_value`](crate::RuntimeFlags::submission_value))
     /// — an engine that shells out keeps those in `command`.
     pub runtime_flags: Option<RuntimeFlags>,
+    /// What memory the run held while it ran
+    /// ([`MemoryObservation`](crate::result::MemoryObservation)), collected on
+    /// every benchmark kind rather than only the memory one.
+    ///
+    /// Filled by the **engine**, unlike `thermal` and `benchmark_flags`:
+    /// sampling the child's memory needs the pid, which only the engine that
+    /// spawned it has. Default is "observed nothing", which a platform without a
+    /// sampler leaves in place.
+    pub memory: MemoryObservation,
 }
 
 impl RunResponse {
@@ -176,6 +185,7 @@ impl RunResponse {
             command: Vec::new(),
             executable: None,
             runtime_flags: None,
+            memory: MemoryObservation::default(),
         }
     }
 }

--- a/crates/pipette-plan-types/src/run.rs
+++ b/crates/pipette-plan-types/src/run.rs
@@ -161,8 +161,8 @@ pub struct RunResponse {
     /// — an engine that shells out keeps those in `command`.
     pub runtime_flags: Option<RuntimeFlags>,
     /// What memory the run held while it ran
-    /// ([`MemoryObservation`](crate::result::MemoryObservation)), collected on
-    /// every benchmark kind rather than only the memory one.
+    /// ([`MemoryObservation`]), collected on every benchmark kind rather than
+    /// only the memory one.
     ///
     /// Filled by the **engine**, unlike `thermal` and `benchmark_flags`:
     /// sampling the child's memory needs the pid, which only the engine that

--- a/docs/methodology/peak-memory-android.md
+++ b/docs/methodology/peak-memory-android.md
@@ -171,7 +171,7 @@ under-read. These figures were taken at the earlier 25 ms interval.
 ## Code References
 
 - [`pipette-llamacpp max_memory_usage::android`](../../crates/pipette-llamacpp/src/execute/max_memory_usage/android.rs)
-- [`pipette-llamacpp max_memory_usage::proc_footprint`](../../crates/pipette-llamacpp/src/execute/max_memory_usage/proc_footprint.rs)
+- [`pipette-llamacpp run_memory::proc_footprint`](../../crates/pipette-llamacpp/src/run_memory/proc_footprint.rs)
 
 ## The VL runner samples resident only
 

--- a/docs/methodology/peak-memory-linux.md
+++ b/docs/methodology/peak-memory-linux.md
@@ -72,7 +72,7 @@ Reading `/proc` avoids wrapping `wait4` around the child, which would race
 `std`'s own reaping in `wait_with_output`.
 
 The sampler is shared with the Android arm
-([`max_memory_usage::proc_footprint`](../../crates/pipette-llamacpp/src/execute/max_memory_usage/proc_footprint.rs)),
+([`run_memory::proc_footprint`](../../crates/pipette-llamacpp/src/run_memory/proc_footprint.rs)),
 which also collects `VmSwap`. This arm reports resident peak only, so it carries
 the swap under-reporting described in
 [peak memory: Android](peak-memory-android.md); adopting the swap-aware figure

--- a/docs/methodology/peak-memory-usage.md
+++ b/docs/methodology/peak-memory-usage.md
@@ -75,8 +75,11 @@ What that costs is bounded rather than nil, and the terms are affected unevenly:
 Coverage is per platform and deliberately incomplete. Android and Linux sample
 `/proc/<pid>/status` and report both terms. macOS reports the host term from
 `phys_footprint`, which already bills compressed pages, so it has no separate
-swap term. Windows reports neither yet: PSAPI is read once after exit through a
-duplicated handle rather than polled, so there is no sampler to attach. A
+swap term. Windows has no sampler to attach: PSAPI is read once after exit
+through a duplicated handle rather than polled, so a Windows run of any *other*
+benchmark reports neither term. The memory benchmark is the exception: it makes
+that single post-exit read anyway, so its rows carry the host term (never the
+swap one) on Windows too. A
 platform that samples nothing contributes no keys, and absence therefore means
 "not observed" rather than zero, while a `0` means the sampler looked and found
 the run resident.

--- a/docs/methodology/peak-memory-usage.md
+++ b/docs/methodology/peak-memory-usage.md
@@ -10,6 +10,79 @@ accelerator memory at the peak, or the workload failed to fit.
 
 In pipette, this metric is reported by the `max_memory_usage` benchmark family.
 
+## Observations vs metrics
+
+Everything in this document describes the `max_memory_usage` **metric**: a
+scored figure produced by a benchmark whose whole job is to measure memory.
+
+Separately, the llama.cpp benchmarks also record what memory they held while
+they ran, as **observations**:
+
+| Column | Meaning |
+|--------|---------|
+| `observation_max_host_bytes` | peak memory the run held, counting compressed or paged-out pages where the platform sees them |
+| `observation_max_swap_bytes` | most of the run the kernel held in swap at once |
+
+These are measured workload facts rather than results, in the same sense as
+`observation_vl_throughput_prefill_tokens`. They exist because a timing number
+means something different depending on the memory conditions it was measured
+under: a decode-throughput row that hit its figure while zram held part of the
+model is not comparable to one measured resident, and nothing else in the row
+says which happened. They carry no benchmark prefix because they are not
+specific to one benchmark type.
+
+`eval` is the deliberate exception and reports neither. It can restart
+`llama-server` mid-run after a crash, so the handle that survives to the end has
+only watched the replacement: any single figure would describe part of the run
+while looking like it described all of it. An absent observation says "not
+observed", which is true, where a partial one would read as complete.
+
+Two properties matter when reading them:
+
+- **The swap term is contained in the host term, not additional to it.** Adding
+  them together double-counts.
+- **`observation_max_host_bytes` need not equal `max_host_bytes` on the same
+  row.** The observation is free to report the swap-aware peak wherever the
+  sampler supplies one; the metric keeps its per-platform definition, and the
+  Linux metric is still resident-only. A Linux row whose observation exceeds its
+  metric is showing exactly that gap.
+
+### The observation must not move the number it rides along with
+
+A benchmark that reports time cannot pay for being watched, so the observer polls
+every 100 ms rather than at the memory benchmark's 10 ms (Android/Linux) or 20 ms
+(macOS). That is two small reads per tenth of a second, roughly 0.1% of one core.
+
+What that costs is bounded rather than nil, and the terms are affected unevenly:
+
+- **The peak counters are watermarks, so we never have to catch the peak's
+  instant.** `VmHWM` on Android/Linux and `ri_lifetime_max_phys_footprint` on
+  macOS are maintained by the kernel, and a later read still returns the highest
+  value reached.
+- **But a watermark has to be read while the process is alive.** An exited
+  process publishes no `Vm*` fields at all, and `proc_pid_rusage` returns ESRCH
+  once the child is reaped, so on both platforms the last useful read precedes
+  exit and any growth in the final interval is missed. In practice these
+  workloads peak at model load, well before the end, which is why the trade is
+  acceptable; 100 ms rather than something rarer keeps the window small, since
+  past that point the saving is immaterial while the window grows in proportion.
+- **The swap term loses resolution on top of that**, since the kernel keeps no
+  watermark for swap and a sampled maximum is the only way to see it. An
+  observation asks "did this run swap, and roughly how much", which a coarse
+  maximum answers. Precision there belongs to the memory benchmark, which keeps
+  its 10 ms cadence because it reports bytes rather than time.
+
+Coverage is per platform and deliberately incomplete. Android and Linux sample
+`/proc/<pid>/status` and report both terms. macOS reports the host term from
+`phys_footprint`, which already bills compressed pages, so it has no separate
+swap term. Windows reports neither yet: PSAPI is read once after exit through a
+duplicated handle rather than polled, so there is no sampler to attach. A
+platform that samples nothing contributes no keys, and absence therefore means
+"not observed" rather than zero, while a `0` means the sampler looked and found
+the run resident.
+
+## The metric
+
 The methodology uses three conceptual result fields:
 
 - `max_host_bytes`: peak host/process memory attributed to the workload.

--- a/docs/methodology/peak-memory-usage.md
+++ b/docs/methodology/peak-memory-usage.md
@@ -20,8 +20,8 @@ they ran, as **observations**:
 
 | Column | Meaning |
 |--------|---------|
-| `observation_max_host_bytes` | peak memory the run held, counting compressed or paged-out pages where the platform sees them |
-| `observation_max_swap_bytes` | most of the run the kernel held in swap at once |
+| `observation_max_host_bytes` | peak **resident** memory the run held (`VmHWM`, `PeakWorkingSetSize`; on macOS `phys_footprint`, which also counts compressed pages) |
+| `observation_max_swap_bytes` | most the kernel held of the run in swap at once |
 
 These are measured workload facts rather than results, in the same sense as
 `observation_vl_throughput_prefill_tokens`. They exist because a timing number
@@ -39,13 +39,30 @@ observed", which is true, where a partial one would read as complete.
 
 Two properties matter when reading them:
 
-- **The swap term is contained in the host term, not additional to it.** Adding
-  them together double-counts.
-- **`observation_max_host_bytes` need not equal `max_host_bytes` on the same
-  row.** The observation is free to report the swap-aware peak wherever the
-  sampler supplies one; the metric keeps its per-platform definition, and the
-  Linux metric is still resident-only. A Linux row whose observation exceeds its
-  metric is showing exactly that gap.
+- **The two terms are independent, and must not be added.** The host term is a
+  resident watermark; the swap term is the largest swap reading sampled. They
+  need not fall at the same instant, so their sum describes no moment that
+  actually happened. What a non-zero swap term tells you is that the resident
+  peak beside it was suppressed by reclaim, and roughly by how much.
+- **`observation_max_host_bytes` is resident-only, so it is not always the same
+  quantity as `max_host_bytes` on the same row.** The Linux metric is also
+  resident-only and the two agree there. The Android metric is the swap-aware
+  peak (`max(VmHWM, max(VmRSS + VmSwap))`), so on a row that swapped it will
+  read *higher* than the observation beside it. That difference is the metric's
+  swap uplift, made legible rather than hidden.
+
+A worked example, measured on a Galaxy S26 Ultra loading a 5417 MiB model with
+`--mmap 0`:
+
+| | |
+|---|---|
+| `observation_max_host_bytes` | 5004 MiB (what stayed resident) |
+| `observation_max_swap_bytes` | 4105 MiB (what zram held at its worst) |
+| Android `max_host_bytes` (metric) | 6138 MiB (the swap-aware peak) |
+
+The resident figure alone is *below the model file*, which a completed no-mmap
+load cannot be; the swap term beside it is what says why, and the metric is what
+scores the real requirement.
 
 ### The observation must not move the number it rides along with
 


### PR DESCRIPTION
**Problem**
A timing number means something different depending on the memory conditions it was measured under. A decode-throughput row that hit its figure while zram held part of the model is not comparable to one measured resident, and nothing in the row said which happened: peak memory was only ever recorded by the benchmark whose job was to measure it.

**Solution**
- Adds `observation_max_host_bytes` and `observation_max_swap_bytes`, collected for **every benchmark the CLI runs except `eval`**, not just `max_memory_usage`. `eval` is the deliberate exception: it can restart `llama-server` mid-run after a crash, so the handle that survives to the end has only watched the replacement, and any single figure would describe part of the run while looking like it described all of it. It reports no observation at all, which is the true statement.
- Records them as **observations, not metrics** -- the established sense of `observation_vl_throughput_prefill_tokens`: measured workload facts that qualify a row rather than score it. They flatten beside the thermal and power observations; `BenchmarkResultData` is untouched.
- Moves the `/proc` sampler out of `max_memory_usage` into `run_memory`, where a per-OS observer attaches to any spawned child. Two hook points cover five of the six llama.cpp benchmarks: `RunningLlamaServer::observe_memory` (e2e, vl — opt-in, which is how `eval` declines it) and `bench::execute` (prefill, decode); the four `max_memory_usage` arms report from the sampling they already do.
- Folds across repetitions with a max per term, since the largest peak and the largest swap need not come from the same rep.

**Semantics**
`observation_max_host_bytes` is the **resident** watermark (`VmHWM`, `PeakWorkingSetSize`), so the field names one quantity wherever it appears; macOS is the exception it cannot avoid, since `phys_footprint` bills compressed pages and the kernel publishes no resident-only counter beside it. `observation_max_swap_bytes` is a term in its own right, **not** a component of the host term and **not additive** with it: the resident watermark and the largest swap reading need not fall at the same instant, so their sum describes no moment that happened. A run that swapped is recognised by a non-zero swap term, not by an inflated peak.

That leaves the swap-aware *sum* where it is already scored, in the `max_memory_usage` metric, whose Android arm reports it. So on an Android row that swapped, the metric reads higher than the observation beside it, and that difference is the metric's swap uplift made legible. Measured on a Galaxy S26 Ultra loading a 5417 MiB model with `--mmap 0`: `observation_max_host_bytes` 5004 MiB, `observation_max_swap_bytes` 4105 MiB, metric `max_host_bytes` 6138 MiB. The resident figure alone is below the model file, which a completed no-mmap load cannot be; the swap term beside it is what says why.

Absence and zero are different: `0` means the sampler looked and the run stayed resident, absence means nothing sampled it.

**Coverage is deliberately partial**

| Platform | host peak | swap |
|---|---|---|
| Android, Linux | yes (`/proc/<pid>/status`) | yes |
| macOS | yes (`phys_footprint`; the one arm whose host term also counts compressed pages) | n/a |
| Windows | not yet | not yet |

Windows reads PSAPI once after exit through a duplicated handle rather than polling, so there is no sampler to attach; wiring it is a follow-up.

**Server side**
`SuccessInput` sets no `deny_unknown_fields`, so these are accepted and ignored until columns exist. No mgmt change is needed to land this.

**Testing**
- Six table-driven cases pin the cross-rep fold: worst-rep-wins, terms taken independently, absence never beating a real reading, and a sampled zero surviving where absence does not.
- A flattening test asserts both fields land at the top level under their `observation_*` names on a **decode-throughput** row, proving the observation rides on non-memory benchmarks.
- The observer has a live-process test that runs on whichever arm it is built for.
- Verified beyond the host target: `aarch64-linux-android` clippy clean, and Linux clippy plus tests green on `edge-ci-linux` (100 passed). `cargo fmt`, workspace clippy, and `./ci/lint.sh` clean.
- **Windows is not locally verified** -- `ring` will not cross-build from macOS and the Windows box has no checkout. The edit there is a struct-literal field plus an import, mechanically identical to the three verified arms, and CI builds the target.
- Unrelated finding: `pipette-torch-oai` fails Linux clippy at `src/server/uv.rs:47` (`duplicated attribute`). Confirmed pre-existing on `main`, not touched here.

