### PR TITLE
feat: stamp non-release builds with a real version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,13 @@ jobs:
 
       - name: Compute release metadata
         id: version
+        env:
+          # On `pull_request` the checkout is the merge commit GitHub built for
+          # the run, and its sha is in neither branch — a version naming it
+          # would point at nothing. Name the PR's head commit, the one the
+          # commit list and `git log` show. Empty on every other event, where
+          # ci/version.sh falls back to HEAD.
+          PIPETTE_VERSION_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Assign first: `echo "v=$(cmd)"` succeeds even when cmd fails, and
           # the default shell is `bash -e` with no pipefail, so piping the echo
@@ -842,17 +849,19 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ${{ matrix.runner }}
     env:
-      # The real date+sha version changes every commit, so on ordinary CI (PR /
-      # main push) runs it would invalidate the crate that bakes it in via
-      # `env!` on each build. Use it only on the release path and fall back to
-      # build.rs's own "dev" default otherwise, keeping the crate cacheable.
+      # Every build stamps its own version — `2026.08.1-3-ga1b2c3d4ab` on the
+      # release path, `2026.08.1-dev-3-g323eeda3ab` elsewhere (ci/version.sh). A
+      # binary taken off a PR run therefore names the release it descends from
+      # and the commit it is, which is the whole reason someone pastes
+      # `--version` into a bug report; the bare `dev` this used to pass on
+      # non-release runs named nothing.
       #
-      # The release path is a PUSH to `release/**` — that is what github-release
-      # gates on, so gating this on workflow_dispatch alone shipped every
-      # released binary reporting `0.1.0 (build dev)` as its `--version` and its
-      # `client_version`. The two conditions must name the same event or the
-      # published artifact does not know what it is.
-      PIPETTE_CLI_BUILD_VERSION: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/heads/release/')) && needs.release-metadata.outputs.version || 'dev' }}
+      # It does change every commit, so the two crates that bake it in via
+      # `env!` recompile and the binaries relink on each run. That cost is
+      # confined to this job: `rust-check` never sets the variable, so the
+      # clippy/test caches — the ones a PR loop actually waits on — are
+      # untouched.
+      PIPETTE_CLI_BUILD_VERSION: ${{ needs.release-metadata.outputs.version }}
       # Compiler-level cache: reuse unchanged compilation units (including
       # workspace crates, which the target-dir cache drops) across runs. Biggest
       # effect on the CPU-bound Windows targets.

--- a/ci/version.sh
+++ b/ci/version.sh
@@ -3,20 +3,40 @@
 # answers "what would this commit publish as?" without pushing.
 #
 #   release/2026.08.1 three commits in -> 2026.08.1-3-ga1b2c3d4ab
-#   anything else                      -> the bare commit sha
+#   three commits past that release    -> 2026.08.1-dev-3-g323eeda3ab
+#   no tag in sight                    -> dev-1284-g323eeda3ab
 #
-# The release form is the train from the branch name, the distance from the
-# branch point, and the commit. Nothing reads the clock and nothing needs a
-# pre-existing tag, so a commit always names itself the same way. It is also
-# the shape `git describe` emits, so tagging branch points later changes
-# nothing.
+# Every form is a train, a number, and the commit — the shape `git describe`
+# emits.
 #
-# The one thing that can renumber a released commit is rewriting main: the
-# distance is measured from `git merge-base origin/main HEAD`, so a force-push
-# that moves the branch point moves the count with it.
+# On a release branch the train is the branch name and the number is the
+# distance from the branch point. Nothing reads the clock and nothing needs a
+# pre-existing tag, so a released commit always names itself the same way. The
+# one thing that can renumber it is rewriting main: the distance is measured
+# from `git merge-base origin/main HEAD`, so a force-push that moves the branch
+# point moves the count with it.
+#
+# Off a release branch the train is the nearest reachable tag with a `-dev`
+# marker, so a branch or PR build says which release it descends from and how
+# far past it the commit sits. Releases are tagged with their whole version
+# string, so the tag's own `-<n>-g<sha>` tail is stripped back to the train
+# first. The marker is what keeps this from being a lie: `client_version` maps
+# a warehouse row to a downloadable release by string equality, and without it
+# a PR build would be indistinguishable from a published release on that train.
+#
+# Unlike the release form, this one does move under a commit: it reads whatever
+# tags the checkout can see, so the same commit built before and after a release
+# is cut answers differently, and a checkout with no tags at all falls back to
+# `dev` and the commit height. That is the trade for saying what a build
+# descends from — nothing consumes these strings except a human reading
+# `--version`, and a release still names itself from its branch alone.
 set -euo pipefail
 
 ref="${GITHUB_REF:-refs/heads/$(git rev-parse --abbrev-ref HEAD)}"
+# The commit to name. On a `pull_request` the checkout is the ephemeral merge
+# commit, whose sha appears nowhere in the PR, so CI passes the PR's head sha
+# here; everywhere else HEAD is already the commit being built.
+sha="${PIPETTE_VERSION_SHA:-HEAD}"
 
 case "$ref" in
   refs/heads/release/*)
@@ -32,5 +52,19 @@ case "$ref" in
     base="$(git merge-base origin/main HEAD)"
     echo "${train}-$(git rev-list --count "${base}..HEAD")-g$(git rev-parse --short=10 HEAD)"
     ;;
-  *) git rev-parse --short=10 HEAD ;;
+  *)
+    # `--abbrev=0` asks only for the tag name; the distance and the commit are
+    # counted below so both arms spell them the same way. It fails when no tag
+    # is reachable, which is the untagged fallback and not an error.
+    if tag="$(git describe --tags --abbrev=0 "$sha" 2>/dev/null)"; then
+      # Shortest-suffix strip, so a train that itself carries hyphens survives:
+      # `2026.08.1-hotfix-2-gabcdef1234` -> `2026.08.1-hotfix`.
+      train="${tag%-*-g*}-dev"
+      steps="$(git rev-list --count "${tag}..${sha}")"
+    else
+      train="dev"
+      steps="$(git rev-list --count "$sha")"
+    fi
+    echo "${train}-${steps}-g$(git rev-parse --short=10 "$sha")"
+    ;;
 esac

--- a/crates/pipette-cli/src/lib.rs
+++ b/crates/pipette-cli/src/lib.rs
@@ -30,8 +30,11 @@
 /// printed. A second, tidier spelling for the wire would break that match for
 /// nothing — the server stores the value opaquely and never parses it.
 ///
-/// Local builds report `dev` (see `build.rs`), so a developer's submissions are
-/// distinguishable from a released build's.
+/// A CI build off the release path carries the `-dev` marker its train never
+/// has, e.g. `2026.08.1-dev-3-g323eeda3ab` — it names the release it descends
+/// from and the commit it is, without being equal to any release. A local build
+/// reports a bare `dev` (see `build.rs`). Either way a developer's submissions
+/// stay distinguishable from a released build's.
 pub const CLIENT_VERSION: &str = env!("PIPETTE_CLI_BUILD_VERSION");
 
 pub mod artifact_ref;


### PR DESCRIPTION
**Problem**
Every CI build off the release path stamped a bare `dev` as its version, so a binary taken from a PR run named neither its branch nor its commit — `pipette --version` and the `client_version` it submits read identically for every branch and every commit.

**Solution**
- Stamps non-release builds as `<train>-dev-<n>-g<sha>` (e.g. `2026.08.1-dev-3-g323eeda385`), with the train taken from the nearest reachable tag and its own `-<n>-g<sha>` tail stripped back
- Keeps the `-dev` marker so a branch build can never equal a published release by string equality, which is how `client_version` maps a warehouse row to a downloadable release
- Falls back to `dev-<height>-g<sha>` when no tag is reachable
- Names the PR head commit rather than the ephemeral merge commit on `pull_request` runs, via `PIPETTE_VERSION_SHA`
- Drops the gate that pinned `PIPETTE_CLI_BUILD_VERSION` to `dev` outside the release path; the resulting per-commit rebuild stays confined to `build-artifact`, since `rust-check` never sets the variable

Released versions are unchanged — the release arm still derives from the branch name alone and needs no tag.

**Testing**
- `ci/version.sh` exercised across release / branch / PR-merge-ref / on-tag / untagged inputs
- `PIPETTE_CLI_BUILD_VERSION="$(ci/version.sh)" cargo build -p pipette-plan` prints `pipette-plan 2026.08.1-dev-3-g323eeda385`
- `ci/lint.sh` passes