### PR TITLE
fix: keep the pre-fetch quota check working on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,19 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Test
+        # `shell: bash` is load-bearing, not style. Windows defaults `run:` to
+        # pwsh, which does not abort on a failing native command and exits with
+        # the *last* one's status — so `cargo nextest` could fail and the step
+        # still went green on the strength of `cargo test --doc` behind it. A
+        # Windows-only failure in `pipette-artifacts` rode that gap. bash gets
+        # `-e -o pipefail`, which is what the other two legs were already using.
+        shell: bash
+        # `--no-fail-fast` so one run reports every failure. nextest's default
+        # cancels on the first, which costs a push per failing test to enumerate
+        # a break that only reproduces on one platform — the leg a contributor
+        # cannot run locally is the one where the full list is worth most. The
+        # extra runtime is only spent on an already-red run.
+        #
         # nextest runs the test binaries in parallel but does not execute
         # doctests, so keep a `--doc` pass to preserve that coverage.
         # Nothing is excluded, matching Clippy above.
@@ -253,7 +266,7 @@ jobs:
         # `native/benchmarks.rs` prompt-seed kernel, memory-peak arithmetic)
         # is pure logic that stubs tokenization.
         run: |
-          cargo nextest run --workspace
+          cargo nextest run --workspace --no-fail-fast
           cargo test --doc --workspace
 
   python-check:

--- a/crates/pipette-artifacts/src/ensure.rs
+++ b/crates/pipette-artifacts/src/ensure.rs
@@ -36,9 +36,11 @@ pub fn ensure_model(
     // and a progress bar needs the same number for a denominator. Skipped when
     // nothing will be fetched — a cache hit costs no bytes, and asking a repo how
     // big they would have been is a network round trip for a number nobody reads.
-    let size = (!stored && (policy.is_some() || ctx.progress.is_some()))
-        .then(|| declared_size_bytes(http, declared))
-        .flatten();
+    let size = if !stored && (policy.is_some() || ctx.progress.is_some()) {
+        pre_fetch_size(ctx, declared)?
+    } else {
+        None
+    };
     if let Some(policy) = policy {
         quota::refuse_if_oversize(&declared.to_string(), size, policy.quota_bytes)?;
     }
@@ -115,6 +117,23 @@ fn sweep(policy: &StoragePolicy, pins: SweepPins) {
     });
 }
 
+/// Bytes `declared` will occupy once fetched, `None` when unknowable.
+///
+/// The failure is kept as a failure. [`declared_size_bytes`] errors only when the
+/// fetch cannot be planned, and answering `None` there would skip the quota
+/// pre-flight and let a fetch that is going to fail anyway run first.
+fn pre_fetch_size(
+    ctx: &ArtifactsContext,
+    declared: &Model,
+) -> Result<Option<u64>, ModelStoreError> {
+    declared_size_bytes(&ctx.download_http_client, declared).map_err(|source| {
+        ModelStoreError::Fetch {
+            model: declared.to_string(),
+            source: source.into(),
+        }
+    })
+}
+
 /// Bytes `declared` will occupy once installed, when knowable before the install.
 ///
 /// `None` means unknowable, and the post-publish sweep is then the only
@@ -146,7 +165,7 @@ pub fn model_download_size(
     if store.find(declared)?.is_some() {
         return Ok(Some(0));
     }
-    Ok(declared_size_bytes(&ctx.download_http_client, declared))
+    pre_fetch_size(ctx, declared)
 }
 
 /// [`model_download_size`] for a runtime. Only the kinds this process downloads
@@ -310,7 +329,10 @@ mod tests {
     /// leaves the store exactly full, so a test that needs an *overage* has to
     /// put bytes somewhere else.
     fn declared_bytes(ctx: &ArtifactsContext, model: &Model) -> u64 {
-        crate::model::fetch::declared_size_bytes(&ctx.download_http_client, model).unwrap_or(0)
+        crate::model::fetch::declared_size_bytes(&ctx.download_http_client, model)
+            .ok()
+            .flatten()
+            .unwrap_or(0)
     }
 
     #[test]

--- a/crates/pipette-artifacts/src/model/fetch.rs
+++ b/crates/pipette-artifacts/src/model/fetch.rs
@@ -563,10 +563,24 @@ pub(crate) fn declared_size_bytes(http: &HttpClient, declared: &Model) -> Option
 }
 
 /// Total `Content-Length` over every file a single-file source would download.
+/// Absolute base for the size probe's throwaway dest.
+///
+/// Never written to: it exists only so [`to_stored`] resolves to its `Absolute*`
+/// arms, which `plan_downloads` requires and refuses a relative dest for. What
+/// decides that is `Path::is_absolute`, and its answer is per-platform — a bare
+/// `/quota-probe` has a root but no drive prefix, so Windows reads it as
+/// relative. Spelled per platform rather than Unix-shaped for that reason: the
+/// Unix form made every remote size probe on Windows return `None`, silently
+/// dropping the pre-fetch quota check to the post-publish sweep.
+#[cfg(windows)]
+const QUOTA_PROBE_BASE: &str = r"C:\quota-probe";
+#[cfg(not(windows))]
+const QUOTA_PROBE_BASE: &str = "/quota-probe";
+
 fn remote_files_size_bytes(http: &HttpClient, declared: &Model) -> Option<u64> {
     // Only the URLs matter here — the probe dest is never written. Going
     // through `plan_downloads` keeps URL and auth derivation single-sourced.
-    let into = to_stored(declared, Path::new("/quota-probe")).ok()?;
+    let into = to_stored(declared, Path::new(QUOTA_PROBE_BASE)).ok()?;
     plan_downloads(declared, &into)
         .ok()?
         .iter()
@@ -727,8 +741,34 @@ mod tests {
 
     const SHA_A: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 
+    /// Store base the planning tests re-home into. Platform-shaped for the same
+    /// reason [`QUOTA_PROBE_BASE`] is: `to_stored` picks its `Absolute*` arms off
+    /// `Path::is_absolute`, whose answer is per-platform, so a bare
+    /// `/store/entry/blobs` is read as relative on Windows and every re-home
+    /// through it fails `RelativePath` validation instead of testing anything.
+    ///
+    /// Note the asymmetry that makes this easy to miss: `AbsolutePath`'s own
+    /// validator is a platform-independent string check that accepts the Unix
+    /// spelling everywhere, so tests handing a literal straight to
+    /// `AbsolutePath::try_new` pass on Windows — only the ones routed through
+    /// `to_stored` break.
+    ///
+    /// Spelled with forward slashes on both platforms because `to_stored`
+    /// normalizes separators to `/`; only the drive prefix differs, which is what
+    /// lets [`dest`] compose expectations from one string.
+    #[cfg(windows)]
+    const BASE: &str = "C:/store/entry/blobs";
+    #[cfg(not(windows))]
+    const BASE: &str = "/store/entry/blobs";
+
     fn base() -> &'static Path {
-        Path::new("/store/entry/blobs")
+        Path::new(BASE)
+    }
+
+    /// The dest a planned download carries for `relative` under [`BASE`], spelled
+    /// the way the planner spells it — separators normalized to `/`.
+    fn dest(relative: &str) -> String {
+        format!("{BASE}/{relative}")
     }
 
     fn hf_repo(revision: Option<&str>, auth: Option<&str>) -> anyhow::Result<HfRepo> {
@@ -772,7 +812,7 @@ mod tests {
             download.sha256.as_ref().map(ToString::to_string).as_deref(),
             Some(SHA_A)
         );
-        assert_eq!(download.dest.as_ref(), "/store/entry/blobs/Q4.gguf");
+        assert_eq!(download.dest.as_ref(), dest("Q4.gguf").as_str());
         Ok(())
     }
 
@@ -829,13 +869,7 @@ mod tests {
             ]
         );
         let dests: Vec<&str> = downloads.iter().map(|d| d.dest.as_ref()).collect();
-        assert_eq!(
-            dests,
-            [
-                "/store/entry/blobs/model.gguf",
-                "/store/entry/blobs/mmproj.gguf",
-            ]
-        );
+        assert_eq!(dests, [dest("model.gguf"), dest("mmproj.gguf")]);
         Ok(())
     }
 
@@ -861,13 +895,7 @@ mod tests {
             "URL sources carry no token"
         );
         let dests: Vec<&str> = downloads.iter().map(|d| d.dest.as_ref()).collect();
-        assert_eq!(
-            dests,
-            [
-                "/store/entry/blobs/model.gguf",
-                "/store/entry/blobs/mmproj.gguf",
-            ]
-        );
+        assert_eq!(dests, [dest("model.gguf"), dest("mmproj.gguf")]);
         Ok(())
     }
 
@@ -1332,6 +1360,19 @@ mod tests {
             }
         });
         Ok(format!("http://{addr}"))
+    }
+
+    /// The probe base has to be absolute by the running platform's rule, not by
+    /// looking Unix-shaped. `plan_downloads` refuses a relative dest, so a base
+    /// the platform reads as relative turns every remote size probe into `None`
+    /// — which is a quota check quietly not happening, not a visible failure.
+    /// Cheap to assert here, and it fails on the platform that would break.
+    #[test]
+    fn the_quota_probe_base_is_absolute_on_this_platform() {
+        assert!(
+            Path::new(QUOTA_PROBE_BASE).is_absolute(),
+            "{QUOTA_PROBE_BASE} is not absolute here"
+        );
     }
 
     #[test]

--- a/crates/pipette-artifacts/src/model/fetch.rs
+++ b/crates/pipette-artifacts/src/model/fetch.rs
@@ -24,7 +24,7 @@ use pipette_plan_types::{
     Model, ModelSource, Openvino, RepoSubpath, ResourceUrl, Sha256, Torch,
 };
 
-use super::stored::to_stored;
+use super::stored::{to_stored, ModelStoredError};
 use crate::progress::{copy_reporting, Reporter};
 
 /// Why [`fetch_model`] couldn't materialize a model.
@@ -42,6 +42,11 @@ pub enum ModelFetchError {
     /// A resolved on-disk destination wasn't a valid [`AbsolutePath`].
     #[error("invalid destination path: {0}")]
     InvalidDestination(String),
+    /// The store-relative destinations for a model couldn't be derived at all,
+    /// so there is no plan to run — a `Url` source naming no file, colliding
+    /// vision leaves, a base that doesn't join into a valid path.
+    #[error(transparent)]
+    UnresolvedDestination(#[from] ModelStoredError),
     /// A directory model's repo (or `prefix` subtree) held no files to fetch —
     /// an empty repo or, more often, a mistyped `prefix`.
     #[error("{0}")]
@@ -276,7 +281,7 @@ fn plan_dir_downloads(
                 dest: local_join(dest_dir, &relative)?,
             })
         })
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<_, ModelFetchError>>()?;
     // An empty plan means an empty repo or — far more likely — a `prefix` that
     // matches nothing (a typo). Fetching it would publish an empty model dir that
     // every later `ensure` resolves as valid, so reject it loudly here.
@@ -507,6 +512,11 @@ fn list_repo_files(
 
 /// `Content-Length` for `url`, from a HEAD. `None` whenever the server declines
 /// to say — the caller then has no size to enforce against.
+///
+/// A failed HEAD is not fatal: servers exist that refuse HEAD and serve the GET
+/// the fetch will make anyway, so a probe failure must not decide the resolve.
+/// It is logged, though — it is the one `None` here that isn't the server
+/// answering, and it is why the quota pre-flight has nothing to check.
 pub(crate) fn content_length(
     http: &HttpClient,
     url: &str,
@@ -521,6 +531,12 @@ pub(crate) fn content_length(
     request
         .send()
         .and_then(reqwest::blocking::Response::error_for_status)
+        .inspect_err(|source| {
+            log::warn!(
+                "sizing {url} failed ({source}); the storage quota cannot be checked before the \
+                 fetch"
+            );
+        })
         .ok()?
         .headers()
         .get(reqwest::header::CONTENT_LENGTH)?
@@ -532,12 +548,23 @@ pub(crate) fn content_length(
 
 /// Bytes `declared` will occupy once fetched, when that is knowable before the
 /// fetch: an exact walk for a local import, `Content-Length` for single-file
-/// downloads, the HuggingFace blob listing for a directory snapshot. `None`
-/// whenever no size can be established, in which case the post-publish sweep is
-/// the only enforcement.
-pub(crate) fn declared_size_bytes(http: &HttpClient, declared: &Model) -> Option<u64> {
+/// downloads, the HuggingFace blob listing for a directory snapshot.
+///
+/// `Ok(None)` is "nobody could say how big this is" — the server declined, the
+/// listing omitted sizes, the source has no installer to size — and leaves the
+/// post-publish sweep as the only enforcement. `Err` is the narrower case where
+/// the fetch could not even be *planned*, and it is an error rather than another
+/// `None` because the two are not interchangeable to the caller: a `None` skips
+/// the quota pre-flight silently, letting the fetch run unchecked into a sweep
+/// that cannot evict the entry it just pinned. Planning here goes through the
+/// same [`to_stored`] and [`plan_downloads`] the fetch will, so an `Err` is the
+/// fetch's own failure surfacing one step early.
+pub(crate) fn declared_size_bytes(
+    http: &HttpClient,
+    declared: &Model,
+) -> Result<Option<u64>, ModelFetchError> {
     let walk = |path: &AbsolutePath| crate::entry::entry_size_bytes(Path::new(path.as_ref()));
-    match declared {
+    Ok(match declared {
         // OS-bundled: nothing lands in the store.
         Model::AppleFoundationText => Some(0),
         Model::GgufText(GgufText {
@@ -558,11 +585,10 @@ pub(crate) fn declared_size_bytes(http: &HttpClient, declared: &Model) -> Option
         Model::Mlx(Mlx { source })
         | Model::Torch(Torch { source })
         | Model::Openvino(Openvino { source }) => hf_dir_size_bytes(http, HF_ENDPOINT, source),
-        Model::GgufText(_) | Model::GgufVision(_) => remote_files_size_bytes(http, declared),
-    }
+        Model::GgufText(_) | Model::GgufVision(_) => remote_files_size_bytes(http, declared)?,
+    })
 }
 
-/// Total `Content-Length` over every file a single-file source would download.
 /// Absolute base for the size probe's throwaway dest.
 ///
 /// Never written to: it exists only so [`to_stored`] resolves to its `Absolute*`
@@ -570,24 +596,31 @@ pub(crate) fn declared_size_bytes(http: &HttpClient, declared: &Model) -> Option
 /// decides that is `Path::is_absolute`, and its answer is per-platform — a bare
 /// `/quota-probe` has a root but no drive prefix, so Windows reads it as
 /// relative. Spelled per platform rather than Unix-shaped for that reason: the
-/// Unix form made every remote size probe on Windows return `None`, silently
-/// dropping the pre-fetch quota check to the post-publish sweep.
+/// Unix form made every remote size probe on Windows fail to plan, dropping the
+/// pre-fetch quota check to the post-publish sweep.
 #[cfg(windows)]
 const QUOTA_PROBE_BASE: &str = r"C:\quota-probe";
 #[cfg(not(windows))]
 const QUOTA_PROBE_BASE: &str = "/quota-probe";
 
-fn remote_files_size_bytes(http: &HttpClient, declared: &Model) -> Option<u64> {
+/// Total `Content-Length` over every file a single-file source would download.
+fn remote_files_size_bytes(
+    http: &HttpClient,
+    declared: &Model,
+) -> Result<Option<u64>, ModelFetchError> {
     // Only the URLs matter here — the probe dest is never written. Going
-    // through `plan_downloads` keeps URL and auth derivation single-sourced.
-    let into = to_stored(declared, Path::new(QUOTA_PROBE_BASE)).ok()?;
-    plan_downloads(declared, &into)
-        .ok()?
+    // through `plan_downloads` keeps URL and auth derivation single-sourced,
+    // and it is why both failures propagate: the fetch plans the same way
+    // against the staging base, so anything that stops a plan forming here
+    // stops one forming there. Swallowing it would trade a real error for a
+    // skipped quota check.
+    let into = to_stored(declared, Path::new(QUOTA_PROBE_BASE))?;
+    Ok(plan_downloads(declared, &into)?
         .iter()
         .try_fold(0u64, |total, download| {
             content_length(http, download.url.as_ref(), download.auth.as_ref())
                 .map(|bytes| total.saturating_add(bytes))
-        })
+        }))
 }
 
 /// Total blob size of the repo subtree a directory model would snapshot.
@@ -597,7 +630,16 @@ fn hf_dir_size_bytes(http: &HttpClient, hf_endpoint: &str, source: &ModelSource)
         return None;
     };
     let prefix_slash = prefix.as_ref().map(|p| format!("{}/", p.as_ref()));
-    let info = repo_info(http, hf_endpoint, repo, true).ok()?;
+    // Not fatal, for the same reason a failed HEAD isn't: the fetch makes its
+    // own listing request and will report the failure itself if it persists.
+    let info = repo_info(http, hf_endpoint, repo, true)
+        .inspect_err(|source| {
+            log::warn!(
+                "sizing {repo} failed ({source}); the storage quota cannot be checked before the \
+                 fetch"
+            );
+        })
+        .ok()?;
     let under_prefix: Vec<_> = info
         .siblings
         .into_iter()
@@ -1327,7 +1369,7 @@ mod tests {
             },
         });
 
-        let size = declared_size_bytes(&test_http()?, &declared);
+        let size = declared_size_bytes(&test_http()?, &declared)?;
 
         assert!(size.is_some_and(|bytes| bytes >= 9000), "{size:?}");
         Ok(())
@@ -1364,9 +1406,10 @@ mod tests {
 
     /// The probe base has to be absolute by the running platform's rule, not by
     /// looking Unix-shaped. `plan_downloads` refuses a relative dest, so a base
-    /// the platform reads as relative turns every remote size probe into `None`
-    /// — which is a quota check quietly not happening, not a visible failure.
-    /// Cheap to assert here, and it fails on the platform that would break.
+    /// the platform reads as relative fails every remote size probe — now a
+    /// reported error rather than a silent `None`, but still a quota check that
+    /// never ran. Cheap to assert here, and it fails on the platform that would
+    /// break.
     #[test]
     fn the_quota_probe_base_is_absolute_on_this_platform() {
         assert!(
@@ -1389,7 +1432,7 @@ mod tests {
             },
         });
 
-        assert_eq!(declared_size_bytes(&test_http()?, &declared), Some(1400));
+        assert_eq!(declared_size_bytes(&test_http()?, &declared)?, Some(1400));
         Ok(())
     }
 
@@ -1403,9 +1446,36 @@ mod tests {
         let (declared, _into) =
             url_text_model(&server.url("/w.gguf"), None, Path::new("/tmp/w.gguf"))?;
 
-        // Nothing to refuse against, so the post-publish sweep becomes the only
-        // enforcement — the fetch itself will surface the 404.
-        assert_eq!(declared_size_bytes(&test_http()?, &declared), None);
+        // A server that won't answer a HEAD is not a planning failure: the plan
+        // formed, the size just isn't in it. Nothing to refuse against, so the
+        // post-publish sweep becomes the only enforcement — and the fetch itself
+        // will surface the 404.
+        assert_eq!(declared_size_bytes(&test_http()?, &declared)?, None);
+        Ok(())
+    }
+
+    /// The counterpart: when no plan can be formed, the size probe must not
+    /// answer `None`. `None` skips the quota pre-flight silently and hands the
+    /// job to a post-publish sweep that cannot evict the entry it just pinned,
+    /// so the failure has to reach the caller. This URL names no file, which is
+    /// the same wall the fetch would hit against the staging base.
+    #[test]
+    fn declared_size_bytes_fails_when_no_plan_can_be_formed() -> anyhow::Result<()> {
+        let declared = Model::GgufText(GgufText {
+            source: GgufTextSource::Url {
+                url: ResourceUrl::try_new("https://example.com/models/".to_owned())?,
+                sha256: None,
+            },
+        });
+
+        let err = declared_size_bytes(&test_http()?, &declared)
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("an unplannable fetch must not size as unknown"))?;
+
+        assert!(
+            matches!(err, ModelFetchError::UnresolvedDestination(_)),
+            "{err:?}"
+        );
         Ok(())
     }
 

--- a/crates/pipette-artifacts/src/model/manifest.rs
+++ b/crates/pipette-artifacts/src/model/manifest.rs
@@ -190,13 +190,22 @@ mod tests {
                 },
             })
         );
+        // Platform-shaped: `bind_under` picks its `Absolute*` arm off
+        // `Path::is_absolute`, and a bare `/ws/models` is relative on Windows —
+        // which sends this through the `Relative*` arm and fails on the leading
+        // `/` instead of asserting the join. Forward slashes on both platforms,
+        // since the join normalizes separators to `/`.
+        #[cfg(windows)]
+        const MODELS_ROOT: &str = "C:/ws/models";
+        #[cfg(not(windows))]
+        const MODELS_ROOT: &str = "/ws/models";
         assert_eq!(
-            manifest.bind_under(Path::new("/ws/models"))?,
+            manifest.bind_under(Path::new(MODELS_ROOT))?,
             Model::GgufText(GgufText {
                 source: GgufTextSource::AbsoluteFile {
-                    path: AbsolutePath::try_new(
-                        "/ws/models/meta__llama__Q4.gguf/blobs/Q4.gguf".to_owned()
-                    )?,
+                    path: AbsolutePath::try_new(format!(
+                        "{MODELS_ROOT}/meta__llama__Q4.gguf/blobs/Q4.gguf"
+                    ))?,
                 },
             })
         );

--- a/crates/pipette-artifacts/src/model/stored.rs
+++ b/crates/pipette-artifacts/src/model/stored.rs
@@ -310,10 +310,41 @@ mod tests {
         })
     }
 
-    /// Absolute base — staging / loader shape.
+    /// Absolute base — staging / loader shape. Platform-shaped because
+    /// [`to_stored`] picks its `Absolute*` arms off `Path::is_absolute`, whose
+    /// answer is per-platform: a bare `/store/entry` has a root but no drive
+    /// prefix, so Windows reads it as relative, every re-home takes the
+    /// `Relative*` branch, and `RelativePath` then rejects the leading `/` —
+    /// the test fails on path spelling without reaching what it meant to assert.
+    ///
+    /// Note the asymmetry that makes this easy to miss: `AbsolutePath`'s own
+    /// validator is a platform-independent string check that accepts the Unix
+    /// spelling everywhere, so the `/elsewhere/w.gguf`-style *inputs* below need
+    /// no such treatment — only bases, and the expectations derived from them.
+    ///
+    /// Forward slashes on both platforms because the joins normalize separators
+    /// to `/`; only the prefix differs, which is what lets [`under`] compose
+    /// every expectation from the one string.
+    #[cfg(windows)]
+    const BASE: &str = "C:/store/entry";
+    #[cfg(not(windows))]
+    const BASE: &str = "/store/entry";
+
     fn base() -> &'static Path {
-        Path::new("/store/entry")
+        Path::new(BASE)
     }
+
+    /// `relative` re-homed under [`BASE`], spelled the way the joins spell it.
+    fn under(relative: &str) -> String {
+        format!("{BASE}/{relative}")
+    }
+
+    /// Models root for the [`under_root`] tests, platform-shaped for the same
+    /// reason as [`BASE`].
+    #[cfg(windows)]
+    const MODELS_ROOT: &str = "C:/ws/models";
+    #[cfg(not(windows))]
+    const MODELS_ROOT: &str = "/ws/models";
 
     /// Models-root-relative base — the store's `stored` shape (`<key>/blobs`).
     fn relative_base() -> &'static Path {
@@ -520,7 +551,7 @@ mod tests {
             local,
             Model::GgufText(GgufText {
                 source: GgufTextSource::AbsoluteFile {
-                    path: AbsolutePath::try_new("/store/entry/Q4.gguf".to_owned())?,
+                    path: AbsolutePath::try_new(under("Q4.gguf"))?,
                 },
             })
         );
@@ -549,10 +580,7 @@ mod tests {
         else {
             return Err(anyhow::anyhow!("expected Absolute gguf-text source"));
         };
-        assert_eq!(
-            path,
-            AbsolutePath::try_new("/store/entry/w.gguf".to_owned())?
-        );
+        assert_eq!(path, AbsolutePath::try_new(under("w.gguf"))?);
         Ok(())
     }
 
@@ -592,8 +620,8 @@ mod tests {
                 _ => Err(anyhow::anyhow!("expected a local dir source")),
             }
         };
-        assert_eq!(dir_of(to_stored(&bare, base())?)?, "/store/entry");
-        assert_eq!(dir_of(to_stored(&sub, base())?)?, "/store/entry/4bit");
+        assert_eq!(dir_of(to_stored(&bare, base())?)?, BASE);
+        assert_eq!(dir_of(to_stored(&sub, base())?)?, under("4bit"));
         Ok(())
     }
 
@@ -608,7 +636,7 @@ mod tests {
             to_stored(&local, base())?,
             Model::GgufText(GgufText {
                 source: GgufTextSource::AbsoluteFile {
-                    path: AbsolutePath::try_new("/store/entry/w.gguf".to_owned())?,
+                    path: AbsolutePath::try_new(under("w.gguf"))?,
                 },
             })
         );
@@ -634,7 +662,7 @@ mod tests {
             }) => dir,
             other => anyhow::bail!("expected absolute dir model, got {other:?}"),
         };
-        assert_eq!(dir.as_ref(), "/store/entry");
+        assert_eq!(dir.as_ref(), BASE);
         Ok(())
     }
 
@@ -672,8 +700,8 @@ mod tests {
             to_stored(&declared, base())?,
             Model::GgufVision(GgufVision {
                 source: GgufVisionSource::AbsoluteFiles {
-                    model: AbsolutePath::try_new("/store/entry/model.gguf".to_owned())?,
-                    mmproj: AbsolutePath::try_new("/store/entry/mmproj.gguf".to_owned())?,
+                    model: AbsolutePath::try_new(under("model.gguf"))?,
+                    mmproj: AbsolutePath::try_new(under("mmproj.gguf"))?,
                 },
             })
         );
@@ -691,9 +719,7 @@ mod tests {
         });
         assert_eq!(
             to_stored(&local, base()),
-            Err(ModelStoredError::CollidingPaths(
-                "/store/entry/weights.gguf".to_owned()
-            ))
+            Err(ModelStoredError::CollidingPaths(under("weights.gguf")))
         );
         Ok(())
     }
@@ -715,10 +741,10 @@ mod tests {
             },
         });
         assert_eq!(
-            under_root(&local, Path::new("/ws/models"))?,
+            under_root(&local, Path::new(MODELS_ROOT))?,
             Model::GgufText(GgufText {
                 source: GgufTextSource::AbsoluteFile {
-                    path: AbsolutePath::try_new("/ws/models/key/blobs/w.gguf".to_owned())?,
+                    path: AbsolutePath::try_new(format!("{MODELS_ROOT}/key/blobs/w.gguf"))?,
                 },
             })
         );
@@ -734,7 +760,7 @@ mod tests {
             },
         });
         assert!(matches!(
-            under_root(&local, Path::new("/ws/models")),
+            under_root(&local, Path::new(MODELS_ROOT)),
             Err(ModelStoredError::NotRelative(_))
         ));
         Ok(())
@@ -750,7 +776,7 @@ mod tests {
             },
         });
         assert!(matches!(
-            under_root(&remote, Path::new("/ws/models")),
+            under_root(&remote, Path::new(MODELS_ROOT)),
             Err(ModelStoredError::NotRelative(_))
         ));
         Ok(())

--- a/crates/pipette-artifacts/src/quota.rs
+++ b/crates/pipette-artifacts/src/quota.rs
@@ -1022,17 +1022,32 @@ mod tests {
         Ok(())
     }
 
+    /// Unix-only because the *fixture* is, not the behaviour: an un-removable
+    /// path is not constructible on Windows with std alone.
+    ///
+    /// Every lever that looks like it should work there is one Rust deliberately
+    /// neutralizes to make Windows behave like Unix:
+    ///
+    /// - Nesting the target under a *file* fails `ENOTDIR` here, but Windows
+    ///   reports that shape as plain `NotFound`, which [`remove_entry`] treats as
+    ///   success — already gone is the outcome it wanted.
+    /// - An open handle does not block it: std opens with `FILE_SHARE_DELETE`.
+    /// - Nor does the read-only attribute: std removes with
+    ///   `FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE`.
+    ///
+    /// What is left is a DENY-DELETE ACL, which means a native dependency for one
+    /// fixture. `apply_sweep`'s failure branch is plain platform-independent
+    /// arithmetic over `remove_entry`'s `Err`, and the linux and macos legs cover
+    /// it, so the coverage lost here is the fixture's reach, not the branch.
+    #[cfg(unix)]
     #[test]
     fn apply_sweep_reports_a_removal_it_could_not_perform() -> anyhow::Result<()> {
         let tmp = tempfile::tempdir()?;
-        let missing = tmp.path().join("nested/entry");
+        // A path whose parent is a file: the unlink cannot succeed.
+        fs::write(tmp.path().join("nested"), b"blocker")?;
         let plan = SweepPlan {
             evictions: vec![StorageEntry {
-                // A path whose parent is a file: the unlink cannot succeed.
-                path: {
-                    fs::write(tmp.path().join("nested"), b"blocker")?;
-                    missing.join("child")
-                },
+                path: tmp.path().join("nested").join("entry").join("child"),
                 label: "blocked".to_owned(),
                 size_bytes: 10,
                 kind: EntryKind::Garbage {

--- a/crates/pipette-torch-oai/src/execute/launch.rs
+++ b/crates/pipette-torch-oai/src/execute/launch.rs
@@ -584,11 +584,16 @@ mod tests {
 
     #[test]
     fn build_launch_uv_binds_venv_and_tags_declared_runtime_ref() -> anyhow::Result<()> {
-        // `require_uv_venv` stats `bin/python`, so the venv has to exist.
+        // `require_uv_venv` stats the in-venv interpreter, so the venv has to
+        // exist. Built through `pipette_venv::venv_python` rather than a literal
+        // `bin/python`: that spelling is `Scripts\python.exe` on Windows, and the
+        // layout module owns the choice precisely so fixtures cannot drift from
+        // what the installer writes and the check reads.
         let tmp = tempfile::tempdir()?;
         let venv = tmp.path().join("venv");
-        std::fs::create_dir_all(venv.join("bin"))?;
-        std::fs::write(venv.join("bin").join("python"), "")?;
+        let python = pipette_venv::venv_python(&venv);
+        std::fs::create_dir_all(pipette_venv::venv_bin(&venv))?;
+        std::fs::write(&python, "")?;
         let model_dir = tmp.path().join("model");
         std::fs::create_dir_all(&model_dir)?;
 


### PR DESCRIPTION
**Problem**
`remote_files_size_bytes` probed download sizes through a hardcoded `/quota-probe` dest. That path has a root but no drive prefix, so `Path::is_absolute` is false on Windows and `plan_downloads` refuses it — the probe returned `None` for every remote model, and the pre-fetch quota check silently fell through to the post-publish sweep.

CI could not have caught it: the test step ran under pwsh, which does not abort on a failing native command and exits with the last one's status, so a failing `cargo nextest` went green behind `cargo test --doc`. Unmasking it surfaced four more Windows-only failures, every one a test fixture hardcoding a Unix assumption the production code does not make.

**Solution**
- Spells the probe base per platform so it is absolute by the running platform's own rule, and asserts that on the platform that would break
- Platform-shapes the store bases in the model path tests: `to_stored` branches on `Path::is_absolute`, while `AbsolutePath`'s own validator is a platform-independent string check — so a Unix-shaped base passes construction and then silently takes the `Relative*` arm
- Builds the venv fixture through `pipette_venv::venv_python` instead of a literal `bin/python`, which is `Scripts\python.exe` on Windows; the layout module owns that choice so fixtures cannot drift from it
- Restricts `apply_sweep_reports_a_removal_it_could_not_perform` to unix: std neutralizes every std-only way to make a removal fail on Windows (`FILE_SHARE_DELETE` on open, `FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE` on remove), leaving a DENY-DELETE ACL as the only lever. The branch under test is platform-independent and the other two legs cover it
- Pins the test step to `shell: bash`, matching the other two legs, and drops fail-fast so one red run reports every failure instead of one per push

**Testing**
- Windows CI is the check that matters and now actually gates: 1923 tests run, against 66 before the first cancel.
- `cargo test -p pipette-artifacts -p pipette-torch-oai --lib` — 328 passing locally; clippy clean.
- Windows-only branches were checked locally with `rustc`/`clippy-driver --target x86_64-pc-windows-msvc --emit=metadata` (the crate itself will not cross-compile — `ring` wants a Windows C toolchain).

**Follow-up from review**
The probe swallowed planning errors into `None`, and `None` means "no size could be established" — so a failure skipped the quota pre-flight silently instead of surfacing. `declared_size_bytes` now returns `Result<Option<u64>, _>`: `Err` when the fetch cannot be planned (the same `to_stored`/`plan_downloads` the fetch runs, so it is the fetch's own failure one step early), `Ok(None)` when the size is genuinely unknowable. The probes that stay non-fatal — a refused HEAD, a failed HF listing — now `warn!` with the URL/repo and the reason the quota cannot be checked. Under this split the original Windows bug would have been a reported error rather than a silent skip.
