### PR TITLE
docs(methodology): state the swap-exclusion policy

### DIFF
--- a/docs/methodology/peak-memory-android.md
+++ b/docs/methodology/peak-memory-android.md
@@ -54,6 +54,12 @@ is the only thing in that field the tool did not print. A suppressed peak is
 therefore diagnosable after the fact: near-zero major faults indicate a run that
 met no pressure, while six figures indicate one that thrashed.
 
+Counting the swapped-out pages makes the figure honest, but a run that needed zram
+is still a run the device could not hold in RAM. Such a run is collected and
+stored, and held back from the published results along with the rest of that model
+and quantization on that device; see
+[Selection policies → Swap exclusion](selection-policies.md#swap-exclusion).
+
 `llama-bench` runs in its own process group so the deadline killer can signal the
 whole group. The sampler pins the process start time from `/proc/<pid>/stat` and
 discards any sample whose start time differs, so a pid recycled after the child is

--- a/docs/methodology/peak-memory-usage.md
+++ b/docs/methodology/peak-memory-usage.md
@@ -277,6 +277,12 @@ the runtime reports token counts that differ from the benchmark shape. A missing
 GPU field is valid only for paths where no GPU probe exists or no matching GPU
 sample was observed.
 
+A run that made the device swap is still collected and stored, but it is held back
+from the published results, together with every other run of that model and
+quantization on that device. That policy covers all benchmarks, not only peak
+memory, so it is stated with the selection rules: see
+[Selection policies → Swap exclusion](selection-policies.md#swap-exclusion).
+
 To compare `max_memory_usage` results:
 
 - Use the same benchmark ID, model, quantization, runtime, and relevant runtime

--- a/docs/methodology/selection-policies.md
+++ b/docs/methodology/selection-policies.md
@@ -81,6 +81,43 @@ a comparison between two models is only fair at the same quantization.
 The selected weight repository and quantization are part of the recorded
 selection and must match for two results to be compared.
 
+## Swap Exclusion
+
+A result describes a model on a device only when the device holds the whole run
+in physical memory. When the operating system moves part of a run to swap, the
+measurement describes a memory-starved device instead of the model. We hold that
+configuration back from the published results.
+
+The exclusion is a display rule, not a collection rule. We still run the
+benchmark, and we still store the result with its full recorded selection and run
+environment. The result stays available for investigation and comparison against a
+later rerun. What the exclusion removes is the public presentation of that number,
+because a swapping run does not answer the question a reader asks of it.
+
+The unit of exclusion is one quantization of one model on one device. A single
+swapping run excludes that quantization on that device in every configuration and
+for every benchmark, not only for peak memory. The context length, benchmark, and
+runtime flags of the run that swapped do not limit the exclusion.
+
+The moment of the swap does not matter. Weights that the kernel compresses during
+model load and pages that it evicts during inference mean the same thing: the
+device lacks the memory for that quantization. Both cases are excluded on the
+same terms.
+
+"Swap" means whatever the platform provides: zram on Android, the Windows page
+file, macOS memory compression and swap files, or a Linux swap partition or file.
+Detection is per platform, and we refine the mechanism as necessary for any
+operating system we support. The exclusion follows from the observation rather than
+from the signal that produced it.
+
+An exclusion is provisional, and it is not a verdict on the model. A swapping run
+raises a question about the cause: the device's memory ceiling, a background
+process that consumed memory, a runtime flag that loads the weights into
+anonymous memory, or a defect in the runtime. We investigate the cause. If the
+same quantization then runs on the same device with no swap, it appears again in a
+later update of the published results. The rerun carries the published number on
+its own; we do not publish the swapping run with a caveat attached.
+
 ## Provider Recommendations
 
 Model and runtime providers are welcome to tell us the best way to run their


### PR DESCRIPTION
**Problem**
Nothing documented what happens to a published number when a run pushes the
device into swap. Such a run measures a memory-starved device rather than the
model, and a reader had no way to know those runs are withheld.

**Solution**
- Adds a `Swap Exclusion` section to the selection policies, beside the quant ladder it prunes
- States the excluded unit: one quantization of one model on one device, in every configuration and for every benchmark
- Treats load-time and inference-time swap on the same terms
- Clarifies that exclusion withholds the number from display while collection and storage continue
- Notes that exclusion is provisional, with re-admission after a clean rerun
- Cross-links the policy from the peak-memory overview and the Android page